### PR TITLE
feat(core): auto-resume interrupted in-flight requests on gateway restart

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1274,7 +1274,14 @@ async function processJob(job: QueueJob, isCancelled: () => boolean): Promise<vo
 
     let result;
     try {
-      await state.setInFlight(job.chatId, { prompt: job.prompt, startedAt: Date.now() });
+      await state.setInFlight(job.chatId, {
+        prompt: job.prompt,
+        kind: job.kind,
+        imagePath: job.imagePath,
+        documentPath: job.documentPath,
+        documentName: job.documentName,
+        startedAt: Date.now(),
+      });
       result = await runAgy(config.agy, job.prompt || "", session?.conversationId || null, {
         ...settings,
         signal: controller.signal,
@@ -1553,13 +1560,30 @@ async function main(): Promise<void> {
   if (Object.keys(interrupted).length > 0) {
     await state.clearAllInFlight();
     for (const [chatId, job] of Object.entries(interrupted)) {
-      const promptSnippet = job.prompt ? ` (Last prompt: <i>"${escapeHtml(job.prompt.slice(0, 50))}${job.prompt.length > 50 ? "..." : ""}"</i>)` : "";
-      await telegram.sendMessage(
-        chatId,
-        `⚡ <b>AGY Gateway restarted</b>\n\nThe service was restarted during your previous request${promptSnippet}.\nI am back online and ready for your next command!`,
-        createMainKeyboard(settingsFor(chatId)),
-        "HTML"
-      ).catch(() => undefined);
+      if (job.prompt || job.kind === "usage" || job.kind === "credits" || job.kind === "context") {
+        const promptSnippet = job.prompt ? ` (Prompt: <i>"${escapeHtml(job.prompt.slice(0, 60))}${job.prompt.length > 60 ? "..." : ""}"</i>)` : "";
+        await telegram.sendMessage(
+          chatId,
+          `⚡ <b>AGY Gateway restarted</b>\n\nYour previous request was interrupted by a restart${promptSnippet}.\n<i>Resuming execution now...</i>`,
+          createMainKeyboard(settingsFor(chatId)),
+          "HTML"
+        ).catch(() => undefined);
+
+        enqueueJob(chatId, {
+          kind: job.kind || "prompt",
+          prompt: job.prompt,
+          imagePath: job.imagePath,
+          documentPath: job.documentPath,
+          documentName: job.documentName,
+        });
+      } else {
+        await telegram.sendMessage(
+          chatId,
+          `⚡ <b>AGY Gateway restarted</b>\n\nI am back online and ready for your next command!`,
+          createMainKeyboard(settingsFor(chatId)),
+          "HTML"
+        ).catch(() => undefined);
+      }
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,10 @@ export interface ConversationSummary {
 
 export interface InFlightJob {
   prompt?: string;
+  kind?: "prompt" | "usage" | "credits" | "context";
+  imagePath?: string;
+  documentPath?: string;
+  documentName?: string;
   startedAt: number;
 }
 


### PR DESCRIPTION
## Summary
Improves resilience when the bot gateway restarts (e.g. systemd watchdog, service updates, host reboots, or container recreation) during an ongoing request:
- **Expanded In-Flight State**: Persists prompt, kind, and media attachment references in `state.inFlight`.
- **Automatic Resumption**: When the gateway boots back up, it notifies the user that the interrupted request is resuming and re-enqueues the job to deliver the full output instead of dropping the request.

## Testing
- Tested state persistence across reloads and automatic re-enqueuing.
- All unit and smoke tests passing (`npm test`).
