### PR TITLE
feat(ui): add persistent Quota quick button beside chat input

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1461,6 +1461,10 @@ async function handleUpdate(update: TelegramUpdate): Promise<void> {
       return;
     }
     if (buttonText === "🤖 Model") { await reply(message.chat.id, "Select a model:", modelKeyboard(message.chat.id)); return; }
+    if (buttonText === "📊 Quota" || buttonText === "📊 Usage / Quota" || buttonText === "📊 Usage") {
+      enqueueJob(message.chat.id, { kind: "usage" });
+      return;
+    }
     if (buttonText.startsWith("⚙ Mode:")) { const settings = settingsFor(message.chat.id); settings.mode = settings.mode === "plan" ? "accept-edits" : "plan"; await saveSettings(message.chat.id, settings); await reply(message.chat.id, `Mode changed to ${settings.mode}.`, createMainKeyboard(settings)); return; }
     if (buttonText.startsWith("📢 Verbose:") || buttonText.startsWith("📢 Verbose")) {
       const settings = settingsFor(message.chat.id);

--- a/src/keyboards.ts
+++ b/src/keyboards.ts
@@ -7,10 +7,10 @@ function verboseLabel(verbose: SessionSettings["verbose"]): string {
 }
 
 /** Persistent keyboard shown immediately above Telegram's input field. */
-export function createMainKeyboard(settings: SessionSettings): ReplyKeyboardMarkup {
+export function createMainKeyboard(_settings?: SessionSettings): ReplyKeyboardMarkup {
   return {
     keyboard: [
-      ["✨ New session", "🤖 Model", `📢 Verbose: ${verboseLabel(settings.verbose)}`],
+      ["✨ New session", "🤖 Model", "📊 Quota"],
     ],
     resize_keyboard: true,
     is_persistent: true,

--- a/test/telegram.test.ts
+++ b/test/telegram.test.ts
@@ -18,17 +18,12 @@ test("splitPreformattedHtml preserves HTML tags without double escaping", () => 
 
 test("splits Telegram messages near line boundaries", () => { const chunks = splitMessage("one\ntwo\nthree\nfour", 8); assert.deepEqual(chunks, ["one\ntwo", "three", "four"]); assert.ok(chunks.every((chunk) => chunk.length <= 8)); });
 
-test("builds a persistent new session, model, and verbose reply keyboard beside the input", () => {
+test("builds a persistent new session, model, and quota reply keyboard beside the input", () => {
   const keyboard = createMainKeyboard({ model: "gemini-3.6-flash-high", effort: "high", mode: "plan", sandbox: true, verbose: "detailed" });
-  assert.deepEqual(keyboard.keyboard, [["✨ New session", "🤖 Model", "📢 Verbose: det"]]);
+  assert.deepEqual(keyboard.keyboard, [["✨ New session", "🤖 Model", "📊 Quota"]]);
   assert.equal(keyboard.resize_keyboard, true);
   assert.equal(keyboard.is_persistent, true);
   assert.equal("inline_keyboard" in keyboard, false);
-});
-
-test("labels compact verbose in the persistent keyboard", () => {
-  const keyboard = createMainKeyboard({ model: null, effort: "medium", mode: "accept-edits", sandbox: true, verbose: "compact" });
-  assert.deepEqual(keyboard.keyboard, [["✨ New session", "🤖 Model", "📢 Verbose: comp"]]);
 });
 
 test("formats AGY Markdown-like responses as safe Telegram HTML", () => {


### PR DESCRIPTION
## Summary
Adds a direct `📊 Quota` quick-access button to the persistent reply keyboard above the chat input:
- Replaces the verbose level toggle in the persistent keyboard with a 1-tap `📊 Quota` check.
- Handles `📊 Quota` taps to instantly trigger `/usage` quota inspection.

## Testing
- Updated keyboard unit tests in `test/telegram.test.ts`.
- All tests passing (`npm test`).
