### PR TITLE
Feat/separate quota models

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1037,6 +1037,13 @@ async function handleCommand(message: TelegramMessage, command: string, args: st
     enqueueJob(chatId, { prompt: promptText, kind: "prompt" });
     return true;
   }
+  if (command === "/compact") {
+    const promptText = args.length > 0
+      ? `Please compact the conversation context: ${args.join(" ")}`
+      : "Please compact our conversation context by consolidating vital state, active goals, decisions, and modified files internally, discarding temporary logs, and providing a concise token savings summary.";
+    enqueueJob(chatId, { prompt: promptText, kind: "prompt" });
+    return true;
+  }
   if (command === "/agy-confirm") { const pending = pendingDangerousCommands.get(String(chatId)); if (!pending) await reply(chatId, "There is no pending dangerous AGY command.", createMainKeyboard(settingsFor(chatId))); else await runCustomAgy(chatId, pending, true); return true; }
   return false;
 }
@@ -1510,6 +1517,7 @@ async function main(): Promise<void> {
     { command: "verbose", description: "Show or change verbose level (detailed, compact, silent)" },
     { command: "session", description: "Show session settings" },
     { command: "learn", description: "Learn reusable rules/skills from recent chat" },
+    { command: "compact", description: "Compact context and create state snapshot to save tokens" },
     { command: "help", description: "Show available commands" },
     { command: "agents", description: "List available AGY agents" },
     { command: "agent", description: "Select an AGY agent" },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1274,7 +1274,14 @@ async function processJob(job: QueueJob, isCancelled: () => boolean): Promise<vo
 
     let result;
     try {
-      await state.setInFlight(job.chatId, { prompt: job.prompt, startedAt: Date.now() });
+      await state.setInFlight(job.chatId, {
+        prompt: job.prompt,
+        kind: job.kind,
+        imagePath: job.imagePath,
+        documentPath: job.documentPath,
+        documentName: job.documentName,
+        startedAt: Date.now(),
+      });
       result = await runAgy(config.agy, job.prompt || "", session?.conversationId || null, {
         ...settings,
         signal: controller.signal,
@@ -1553,13 +1560,30 @@ async function main(): Promise<void> {
   if (Object.keys(interrupted).length > 0) {
     await state.clearAllInFlight();
     for (const [chatId, job] of Object.entries(interrupted)) {
-      const promptSnippet = job.prompt ? ` (Last prompt: <i>"${escapeHtml(job.prompt.slice(0, 50))}${job.prompt.length > 50 ? "..." : ""}"</i>)` : "";
-      await telegram.sendMessage(
-        chatId,
-        `⚡ <b>AGY Gateway restarted</b>\n\nThe service was restarted during your previous request${promptSnippet}.\nI am back online and ready for your next command!`,
-        createMainKeyboard(settingsFor(chatId)),
-        "HTML"
-      ).catch(() => undefined);
+      if (job.prompt || job.kind === "usage" || job.kind === "credits" || job.kind === "context") {
+        const promptSnippet = job.prompt ? ` (Prompt: <i>"${escapeHtml(job.prompt.slice(0, 60))}${job.prompt.length > 60 ? "..." : ""}"</i>)` : "";
+        await telegram.sendMessage(
+          chatId,
+          `⚡ <b>AGY Gateway restarted</b>\n\nYour previous request was interrupted by a restart${promptSnippet}.\n<i>Resuming execution now...</i>`,
+          createMainKeyboard(settingsFor(chatId)),
+          "HTML"
+        ).catch(() => undefined);
+
+        enqueueJob(chatId, {
+          kind: job.kind || "prompt",
+          prompt: job.prompt,
+          imagePath: job.imagePath,
+          documentPath: job.documentPath,
+          documentName: job.documentName,
+        });
+      } else {
+        await telegram.sendMessage(
+          chatId,
+          `⚡ <b>AGY Gateway restarted</b>\n\nI am back online and ready for your next command!`,
+          createMainKeyboard(settingsFor(chatId)),
+          "HTML"
+        ).catch(() => undefined);
+      }
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1461,6 +1461,10 @@ async function handleUpdate(update: TelegramUpdate): Promise<void> {
       return;
     }
     if (buttonText === "🤖 Model") { await reply(message.chat.id, "Select a model:", modelKeyboard(message.chat.id)); return; }
+    if (buttonText === "📊 Quota" || buttonText === "📊 Usage / Quota" || buttonText === "📊 Usage") {
+      enqueueJob(message.chat.id, { kind: "usage" });
+      return;
+    }
     if (buttonText.startsWith("⚙ Mode:")) { const settings = settingsFor(message.chat.id); settings.mode = settings.mode === "plan" ? "accept-edits" : "plan"; await saveSettings(message.chat.id, settings); await reply(message.chat.id, `Mode changed to ${settings.mode}.`, createMainKeyboard(settings)); return; }
     if (buttonText.startsWith("📢 Verbose:") || buttonText.startsWith("📢 Verbose")) {
       const settings = settingsFor(message.chat.id);

--- a/src/keyboards.ts
+++ b/src/keyboards.ts
@@ -7,10 +7,10 @@ function verboseLabel(verbose: SessionSettings["verbose"]): string {
 }
 
 /** Persistent keyboard shown immediately above Telegram's input field. */
-export function createMainKeyboard(settings: SessionSettings): ReplyKeyboardMarkup {
+export function createMainKeyboard(_settings?: SessionSettings): ReplyKeyboardMarkup {
   return {
     keyboard: [
-      ["✨ New session", "🤖 Model", `📢 Verbose: ${verboseLabel(settings.verbose)}`],
+      ["✨ New session", "🤖 Model", "📊 Quota"],
     ],
     resize_keyboard: true,
     is_persistent: true,

--- a/src/pty-runner.ts
+++ b/src/pty-runner.ts
@@ -89,14 +89,9 @@ export function parseUsageQuota(rawOutput: string): string {
 
   const hasGeminiLimits = Boolean(gemini.weekly || gemini.fiveHour);
   const hasClaudeLimits = Boolean(claude.weekly || claude.fiveHour);
-  const isSharedPool =
-    hasGeminiLimits &&
-    hasClaudeLimits &&
-    gemini.weekly === claude.weekly &&
-    gemini.fiveHour === claude.fiveHour;
 
-  if (isSharedPool) {
-    lines.push("<b>Antigravity Quota (All Models)</b>");
+  if (hasGeminiLimits) {
+    lines.push("<b>Gemini Models</b>");
     if (gemini.weekly) {
       lines.push(
         `• Weekly Limit: <b>${gemini.weekly}</b>${gemini.weeklyRefresh ? ` (Refreshes in ${gemini.weeklyRefresh})` : ""}`
@@ -107,32 +102,35 @@ export function parseUsageQuota(rawOutput: string): string {
         `• 5-Hour Limit: <b>${gemini.fiveHour}</b>${gemini.fiveHourRefresh ? ` (Refreshes in ${gemini.fiveHourRefresh})` : ""}`
       );
     }
-  } else {
-    if (hasGeminiLimits) {
-      lines.push("<b>Gemini Models</b>");
-      if (gemini.weekly) {
-        lines.push(
-          `• Weekly Limit: <b>${gemini.weekly}</b>${gemini.weeklyRefresh ? ` (Refreshes in ${gemini.weeklyRefresh})` : ""}`
-        );
-      }
-      if (gemini.fiveHour) {
-        lines.push(
-          `• 5-Hour Limit: <b>${gemini.fiveHour}</b>${gemini.fiveHourRefresh ? ` (Refreshes in ${gemini.fiveHourRefresh})` : ""}`
-        );
-      }
-      lines.push("");
-    }
+  }
 
-    if (hasClaudeLimits) {
-      lines.push("<b>Claude & GPT Models</b>");
-      if (claude.weekly) {
+  if (hasClaudeLimits) {
+    if (hasGeminiLimits) lines.push("");
+    lines.push("<b>Claude & GPT Models</b>");
+    if (claude.weekly) {
+      lines.push(
+        `• Weekly Limit: <b>${claude.weekly}</b>${claude.weeklyRefresh ? ` (Refreshes in ${claude.weeklyRefresh})` : ""}`
+      );
+    }
+    if (claude.fiveHour) {
+      lines.push(
+        `• 5-Hour Limit: <b>${claude.fiveHour}</b>${claude.fiveHourRefresh ? ` (Refreshes in ${claude.fiveHourRefresh})` : ""}`
+      );
+    }
+  }
+
+  if (!hasGeminiLimits && !hasClaudeLimits) {
+    const general = extractLimits(text);
+    if (general.weekly || general.fiveHour) {
+      lines.push("<b>Antigravity Quota</b>");
+      if (general.weekly) {
         lines.push(
-          `• Weekly Limit: <b>${claude.weekly}</b>${claude.weeklyRefresh ? ` (Refreshes in ${claude.weeklyRefresh})` : ""}`
+          `• Weekly Limit: <b>${general.weekly}</b>${general.weeklyRefresh ? ` (Refreshes in ${general.weeklyRefresh})` : ""}`
         );
       }
-      if (claude.fiveHour) {
+      if (general.fiveHour) {
         lines.push(
-          `• 5-Hour Limit: <b>${claude.fiveHour}</b>${claude.fiveHourRefresh ? ` (Refreshes in ${claude.fiveHourRefresh})` : ""}`
+          `• 5-Hour Limit: <b>${general.fiveHour}</b>${general.fiveHourRefresh ? ` (Refreshes in ${general.fiveHourRefresh})` : ""}`
         );
       }
     }

--- a/src/pty-runner.ts
+++ b/src/pty-runner.ts
@@ -18,27 +18,33 @@ function stripProgressBar(str: string): string {
 export function parseUsageQuota(rawOutput: string): string {
   const text = cleanAnsi(rawOutput).trim();
 
+  // The TUI autocomplete list can contain 'Gemini', 'Claude', etc.
+  // Find the last occurrence of Models & Quota to isolate the rendered command result panel.
+  const quotaMatches = [...text.matchAll(/(?:└\s*)?Models\s*&\s*Quota/gi)];
+  const quotaStart = quotaMatches.length ? quotaMatches[quotaMatches.length - 1].index ?? -1 : -1;
+  const panel = quotaStart >= 0 ? text.slice(quotaStart) : text;
+
   // Validate that the output contains actual quota information, not just a startup screen
   const hasQuotaIndicator =
-    /models?\s*&\s*quota|weekly\s*limit|gemini\s*models?|claude\s*(?:and|\/)\s*gpt|quota\s*available/i.test(text);
+    /models?\s*&\s*quota|weekly\s*limit|gemini\s*models?|claude\s*(?:and|\/|&)\s*gpt|quota\s*available/i.test(panel);
   if (!hasQuotaIndicator) {
     throw new Error(
-      `AGY did not produce a Models & Quota report.\n\nCaptured output:\n${text.slice(0, 500) || "(empty)"}`
+      `AGY did not produce a Models & Quota report.\n\nCaptured output:\n${panel.slice(0, 500) || "(empty)"}`
     );
   }
 
   // Extract account email
-  const accountMatch = text.match(/(?:Account|User|Email):\s*([^\n\r]+)/i);
+  const accountMatch = panel.match(/(?:Account|User|Email):\s*([^\n\r]+)/i);
   const account = accountMatch ? accountMatch[1].trim() : null;
 
-  // Split into Gemini and Claude sections
-  const geminiPartMatch = text.match(
-    /(?:GEMINI\s*MODELS?|Gemini)[\s\S]*?(?=(?:CLAUDE\s*(?:AND|\/)\s*GPT(?:\s*MODELS?)?|Claude)|$)/i
+  // Split into Gemini and Claude sections within the quota panel
+  const geminiPartMatch = panel.match(
+    /(?:GEMINI\s*MODELS?|Gemini\s+Models?)[\s\S]*?(?=(?:CLAUDE\s*(?:AND|&|\/)\s*GPT(?:\s*MODELS?)?|Claude\s+Models?)|$)/i
   );
   const geminiPart = geminiPartMatch ? geminiPartMatch[0] : "";
 
-  const claudePartMatch = text.match(
-    /(?:CLAUDE\s*(?:AND|\/)\s*GPT(?:\s*MODELS?)?|Claude)[\s\S]*$/i
+  const claudePartMatch = panel.match(
+    /(?:CLAUDE\s*(?:AND|&|\/)\s*GPT(?:\s*MODELS?)?|Claude\s+Models?)[\s\S]*$/i
   );
   const claudePart = claudePartMatch ? claudePartMatch[0] : "";
 
@@ -49,6 +55,8 @@ export function parseUsageQuota(rawOutput: string): string {
     let weeklyRefresh: string | null = null;
     let fiveHour: string | null = null;
     let fiveHourRefresh: string | null = null;
+
+    if (!sectionText) return { weekly, weeklyRefresh, fiveHour, fiveHourRefresh };
 
     // Weekly limit
     const weeklyMatch = sectionText.match(
@@ -120,7 +128,7 @@ export function parseUsageQuota(rawOutput: string): string {
   }
 
   if (!hasGeminiLimits && !hasClaudeLimits) {
-    const general = extractLimits(text);
+    const general = extractLimits(panel);
     if (general.weekly || general.fiveHour) {
       lines.push("<b>Antigravity Quota</b>");
       if (general.weekly) {

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -495,14 +495,16 @@ function parseMarkdownTableCells(line: string): string[] {
 }
 
 function cleanCellText(cell: string): string {
-  return cell
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
-    .replace(/\*\*([^*]+)\*\*/g, "$1")
-    .replace(/__([^_]+)__/g, "$1")
-    .replace(/\*([^*]+)\*/g, "$1")
-    .replace(/_([^_]+)_/g, "$1")
-    .replace(/`([^`]+)`/g, "$1")
-    .trim();
+  return sanitizeLatexExpressions(
+    cell
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+      .replace(/\*\*([^*]+)\*\*/g, "$1")
+      .replace(/__([^_]+)__/g, "$1")
+      .replace(/\*([^*]+)\*/g, "$1")
+      .replace(/_([^_]+)_/g, "$1")
+      .replace(/`([^`]+)`/g, "$1")
+      .trim()
+  );
 }
 
 function formatMarkdownTable(tableLines: string[]): string | null {
@@ -571,6 +573,190 @@ function stripHtmlTags(value: string): string {
   return value.replace(/<[^>]*>/g, "");
 }
 
+const GREEK_MAP: Record<string, string> = {
+  alpha: "α", beta: "β", gamma: "γ", Gamma: "Γ",
+  delta: "δ", Delta: "Δ", epsilon: "ε", varepsilon: "ε",
+  zeta: "ζ", eta: "η", theta: "θ", vartheta: "θ", Theta: "Θ",
+  iota: "ι", kappa: "κ", lambda: "λ", Lambda: "Λ",
+  mu: "µ", nu: "ν", xi: "ξ", Xi: "Ξ",
+  pi: "π", Pi: "Π", rho: "ρ", sigma: "σ", Sigma: "Σ",
+  tau: "τ", upsilon: "υ", phi: "φ", varphi: "φ", Phi: "Φ",
+  chi: "χ", psi: "ψ", Psi: "Ψ", omega: "ω", Omega: "Ω",
+};
+
+const SYMBOL_MAP: Record<string, string> = {
+  rightarrow: "→", to: "→", longrightarrow: "⟶",
+  leftarrow: "←", gets: "←", longleftarrow: "⟵",
+  Rightarrow: "⇒", Leftarrow: "⇐",
+  leftrightarrow: "↔", Leftrightarrow: "⇔", iff: "⇔",
+  uparrow: "↑", downarrow: "↓", mapsto: "↦",
+  approx: "≈", sim: "∼", simeq: "≃", cong: "≅",
+  neq: "≠", ne: "≠",
+  le: "≤", leq: "≤", ge: "≥", geq: "≥",
+  ll: "≪", gg: "≫",
+  pm: "±", mp: "∓",
+  times: "×", cdot: "·", div: "÷",
+  circ: "°", degree: "°",
+  infty: "∞",
+  in: "∈", notin: "∉", ni: "∋",
+  subset: "⊂", supset: "⊃", subseteq: "⊆", supseteq: "⊇",
+  cup: "∪", cap: "∩",
+  forall: "∀", exists: "∃", nexists: "∄",
+  nabla: "∇", partial: "∂",
+  sum: "∑", prod: "∏", int: "∫",
+  ldots: "…", cdots: "…", dots: "…",
+};
+
+const SUPERSCRIPT_MAP: Record<string, string> = {
+  "0": "⁰", "1": "¹", "2": "²", "3": "³", "4": "⁴",
+  "5": "⁵", "6": "⁶", "7": "⁷", "8": "⁸", "9": "⁹",
+  "+": "⁺", "-": "⁻", "=": "⁼", "(": "⁽", ")": "⁾",
+  n: "ⁿ", i: "ⁱ",
+};
+
+const SUBSCRIPT_MAP: Record<string, string> = {
+  "0": "₀", "1": "₁", "2": "₂", "3": "₃", "4": "₄",
+  "5": "₅", "6": "₆", "7": "₇", "8": "₈", "9": "₉",
+  "+": "₊", "-": "₋", "=": "₌", "(": "₍", ")": "₎",
+  a: "ₐ", e: "ₑ", h: "ₕ", i: "ᵢ", j: "ⱼ", k: "ₖ",
+  l: "ₗ", m: "ₘ", n: "ₙ", o: "ₒ", p: "ₚ", r: "ᵣ",
+  s: "ₛ", t: "ₜ", u: "ᵤ", v: "ᵥ", x: "ₓ",
+};
+
+function toSuperscript(str: string): string {
+  return str.split("").map((ch) => SUPERSCRIPT_MAP[ch] || ch).join("");
+}
+
+function toSubscript(str: string): string {
+  return str.split("").map((ch) => SUBSCRIPT_MAP[ch] || ch).join("");
+}
+
+function extractBracedArg(text: string, startIndex: number): { content: string; endIndex: number } | null {
+  if (text[startIndex] !== "{") return null;
+  let depth = 0;
+  const start = startIndex + 1;
+  for (let i = startIndex; i < text.length; i++) {
+    if (text[i] === "\\") {
+      i++;
+      continue;
+    }
+    if (text[i] === "{") depth++;
+    else if (text[i] === "}") {
+      depth--;
+      if (depth === 0) {
+        return { content: text.slice(start, i), endIndex: i };
+      }
+    }
+  }
+  return null;
+}
+
+function replaceFractions(text: string): string {
+  let result = "";
+  let i = 0;
+  while (i < text.length) {
+    if (text.startsWith("\\frac", i)) {
+      const firstBraceIdx = i + 5;
+      const num = extractBracedArg(text, firstBraceIdx);
+      if (num) {
+        const secondBraceIdx = num.endIndex + 1;
+        const den = extractBracedArg(text, secondBraceIdx);
+        if (den) {
+          result += `(${cleanLatexMath(num.content)})/(${cleanLatexMath(den.content)})`;
+          i = den.endIndex + 1;
+          continue;
+        }
+      }
+    }
+    result += text[i];
+    i++;
+  }
+  return result;
+}
+
+export function cleanLatexMath(expr: string): string {
+  let res = expr;
+  res = replaceFractions(res);
+
+  while (res.includes("\\sqrt")) {
+    const idx = res.indexOf("\\sqrt");
+    const braced = extractBracedArg(res, idx + 5);
+    if (braced) {
+      const inner = cleanLatexMath(braced.content);
+      res = res.slice(0, idx) + `√(${inner})` + res.slice(braced.endIndex + 1);
+    } else {
+      break;
+    }
+  }
+
+  while (/\\(?:text|mathrm|mathbf|textbf|mathit|textit|operatorname)\{/.test(res)) {
+    const match = res.match(/\\(?:text|mathrm|mathbf|textbf|mathit|textit|operatorname)\{/);
+    if (!match || match.index === undefined) break;
+    const startIdx = match.index + match[0].length - 1;
+    const braced = extractBracedArg(res, startIdx);
+    if (braced) {
+      res = res.slice(0, match.index) + braced.content + res.slice(braced.endIndex + 1);
+    } else {
+      break;
+    }
+  }
+
+  res = res.replace(/\{,\}/g, ",");
+  res = res.replace(/\\([%$_{}#])/g, "$1");
+  res = res.replace(/\\&amp;/g, "&amp;");
+  res = res.replace(/\\&/g, "&amp;");
+  res = res.replace(/\\[,;: ]/g, " ");
+  res = res.replace(/\\!/g, "");
+  res = res.replace(/\\q?quad/g, "  ");
+
+  res = res.replace(/\^\{([^{}]+)\}/g, (_, exp: string) => toSuperscript(exp));
+  res = res.replace(/\_\{([^{}]+)\}/g, (_, sub: string) => toSubscript(sub));
+  res = res.replace(/\^([0-9+-ni])/g, (_, exp: string) => toSuperscript(exp));
+  res = res.replace(/\_([0-9+-aeh-pr-tv-x])/g, (_, sub: string) => toSubscript(sub));
+
+  res = res.replace(/\\([a-zA-Z]+)/g, (_match, name: string) => {
+    if (SYMBOL_MAP[name]) return SYMBOL_MAP[name];
+    if (GREEK_MAP[name]) return GREEK_MAP[name];
+    return name;
+  });
+
+  res = res.replace(/\{([^{}]+)\}/g, "$1");
+
+  return res.trim().replace(/\s{2,}/g, " ");
+}
+
+export function sanitizeLatexExpressions(text: string): string {
+  let result = text;
+
+  // Block math: $$ ... $$ or \[ ... \]
+  result = result.replace(/\$\$([\s\S]+?)\$\$/g, (_, inner: string) => cleanLatexMath(inner));
+  result = result.replace(/\\\[([\s\S]+?)\\\]/g, (_, inner: string) => cleanLatexMath(inner));
+
+  // Inline math: \( ... \)
+  result = result.replace(/\\\(([\s\S]+?)\\\)/g, (_, inner: string) => cleanLatexMath(inner));
+
+  // Inline math: $ ... $
+  result = result.replace(/\$([^\$\n]+?)\$/g, (match, inner: string) => {
+    const trimmed = inner.trim();
+    if (!trimmed) return match;
+    if (
+      /\\[a-zA-Z,;:! %$_{}#&]/.test(trimmed) ||
+      /[\^_{}]/.test(trimmed) ||
+      /[=<>≤≥≈≠±×·÷]/.test(trimmed) ||
+      /^[a-zA-Z]$/.test(trimmed) ||
+      /^[0-9.,\s+\-*\/()]+[+\-*\/][0-9.,\s+\-*\/()]+$/.test(trimmed)
+    ) {
+      return cleanLatexMath(inner);
+    }
+    return match;
+  });
+
+  // Also clean loose LaTeX symbols outside delimiters (e.g. \rightarrow, \approx, \text{...})
+  result = cleanLatexMath(result);
+
+  return result;
+}
+
 function formatInlineHtml(value: string): string {
   const tokens: string[] = [];
   const token = (html: string): string => {
@@ -600,6 +786,10 @@ function formatInlineHtml(value: string): string {
     return token(`<code>${cleanLabel}</code>`);
   });
   escaped = escaped.replace(/`([^`\n]+)`/g, (_match, code: string) => token(`<code>${code}</code>`));
+
+  // Sanitize LaTeX math and TeX macros in regular text outside code blocks & links
+  escaped = sanitizeLatexExpressions(escaped);
+
   escaped = escaped.replace(/\*\*(.+?)\*\*|__(.+?)__/g, (_match, boldA: string | undefined, boldB: string | undefined) => `<b>${boldA || boldB}</b>`);
   escaped = escaped.replace(/~~(.+?)~~/g, "<s>$1</s>");
   escaped = escaped.replace(/\*([^*\n]+)\*|_([^_\n]+)_/g, (_match, italicA: string | undefined, italicB: string | undefined) => `<i>${italicA || italicB}</i>`);

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -200,6 +200,9 @@ function renderTelegramBlocks(text: string): string[] {
         codeLines = null;
         codeLanguage = "";
       } else {
+        if (output.length > 0 && output[output.length - 1] !== "") {
+          output.push("");
+        }
         codeLines = [];
         codeLanguage = fence[1] || "";
       }
@@ -207,6 +210,51 @@ function renderTelegramBlocks(text: string): string[] {
     }
     if (codeLines) {
       codeLines.push(line);
+      continue;
+    }
+
+    // Blockquote & GitHub Alerts
+    if (line.match(/^\s*>/)) {
+      const quoteLines: string[] = [];
+      while (i < lines.length && lines[i].match(/^\s*>/)) {
+        quoteLines.push(lines[i].replace(/^\s*>\s?/, ""));
+        i++;
+      }
+      i--; // loop will increment i
+
+      let alertHeader = "";
+      if (quoteLines.length > 0) {
+        const alertMatch = quoteLines[0].match(/^\s*\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*(.*)$/i);
+        if (alertMatch) {
+          const type = alertMatch[1].toUpperCase();
+          const rest = alertMatch[2];
+          const iconMap: Record<string, string> = {
+            NOTE: "ℹ️ <b>Note</b>",
+            TIP: "💡 <b>Tip</b>",
+            IMPORTANT: "📌 <b>Important</b>",
+            WARNING: "⚠️ <b>Warning</b>",
+            CAUTION: "🚨 <b>Caution</b>",
+          };
+          alertHeader = iconMap[type] || `📌 <b>${type}</b>`;
+          quoteLines.shift();
+          if (rest.trim()) {
+            quoteLines.unshift(rest.trim());
+          }
+        }
+      }
+
+      const formattedQuote = quoteLines.map((q) => formatInlineHtml(q)).join("\n");
+      const finalQuoteHtml = alertHeader
+        ? `<blockquote>${alertHeader}\n${formattedQuote}</blockquote>`
+        : `<blockquote>${formattedQuote}</blockquote>`;
+
+      if (output.length > 0 && output[output.length - 1] !== "") {
+        output.push("");
+      }
+      output.push(finalQuoteHtml);
+      if (i + 1 < lines.length && lines[i + 1].trim() !== "") {
+        output.push("");
+      }
       continue;
     }
 
@@ -220,7 +268,13 @@ function renderTelegramBlocks(text: string): string[] {
       }
       const renderedTable = formatMarkdownTable(tableLines);
       if (renderedTable) {
+        if (output.length > 0 && output[output.length - 1] !== "") {
+          output.push("");
+        }
         output.push(renderedTable);
+        if (j < lines.length && lines[j].trim() !== "") {
+          output.push("");
+        }
         i = j - 1;
         continue;
       }
@@ -228,23 +282,52 @@ function renderTelegramBlocks(text: string): string[] {
 
     const divider = line.match(/^\s*[-*_]{3,}\s*$/);
     if (divider) {
-      output.push("");
+      if (output.length > 0 && output[output.length - 1] !== "") {
+        output.push("");
+      }
+      output.push("───────────────");
+      if (i + 1 < lines.length && lines[i + 1].trim() !== "") {
+        output.push("");
+      }
       continue;
     }
 
     const heading = line.match(/^\s{0,3}#{1,6}\s+(.+?)\s*#*\s*$/);
     if (heading) {
+      if (output.length > 0 && output[output.length - 1] !== "") {
+        output.push("");
+      }
       output.push(`<b>${formatInlineHtml(heading[1])}</b>`);
       continue;
     }
-    const bullet = line.match(/^\s*[-*+]\s+(.+)$/);
-    if (bullet) {
-      output.push(`• ${formatInlineHtml(bullet[1])}`);
+
+    const checkbox = line.match(/^(\s*)[-*+]\s+\[([ xX])\]\s+(.+)$/);
+    if (checkbox) {
+      const indentLevel = Math.min(3, Math.floor(checkbox[1].length / 2));
+      const indent = "  ".repeat(indentLevel);
+      const icon = checkbox[2].trim() ? "✅" : "⬜";
+      output.push(`${indent}${icon} ${formatInlineHtml(checkbox[3])}`);
       continue;
     }
+
+    const bullet = line.match(/^(\s*)[-*+]\s+(.+)$/);
+    if (bullet) {
+      const indentSpaces = bullet[1].length;
+      if (indentSpaces >= 4) {
+        output.push(`    – ${formatInlineHtml(bullet[2])}`);
+      } else if (indentSpaces >= 2) {
+        output.push(`  ▫️ ${formatInlineHtml(bullet[2])}`);
+      } else {
+        output.push(`• ${formatInlineHtml(bullet[2])}`);
+      }
+      continue;
+    }
+
     const numbered = line.match(/^\s*(\d+)[.)]\s+(.+)$/);
     if (numbered) {
-      output.push(`${numbered[1]}. ${formatInlineHtml(numbered[2])}`);
+      const indentSpaces = numbered[1].length;
+      const indent = indentSpaces >= 2 ? "  " : "";
+      output.push(`${indent}${numbered[1]}. ${formatInlineHtml(numbered[2])}`);
       continue;
     }
     output.push(formatInlineHtml(line));
@@ -299,48 +382,51 @@ function formatMarkdownTable(tableLines: string[]): string | null {
   const rawRows = tableLines.filter((_, idx) => idx !== sepIndex).map(parseMarkdownTableCells);
   if (rawRows.length === 0) return null;
 
-  const cleanRows = rawRows.map((row) => row.map(cleanCellText));
-  const colCount = Math.max(...cleanRows.map((r) => r.length));
+  const headerRow = rawRows[0];
+  const colCount = Math.max(...rawRows.map((r) => r.length));
   if (colCount === 0) return null;
 
-  const colWidths = Array.from({ length: colCount }, (_, colIdx) =>
-    Math.max(
-      3,
-      ...cleanRows.map((row) => (row[colIdx] ? row[colIdx].length : 0))
-    )
-  );
+  const cardBlocks: string[] = [];
 
-  const formattedRows: string[] = [];
-  const headerRow = cleanRows[0];
-  const headerFormatted = colWidths
-    .map((width, colIdx) => (headerRow[colIdx] || "").padEnd(width))
-    .join("  ")
-    .trimEnd();
-  formattedRows.push(headerFormatted);
+  for (let r = 1; r < rawRows.length; r++) {
+    const row = rawRows[r];
+    if (row.every((c) => !c.trim())) continue;
 
-  const totalWidth = colWidths.reduce((sum, w) => sum + w, 0) + (colCount - 1) * 2;
-  formattedRows.push("─".repeat(Math.max(totalWidth, 10)));
-
-  for (let r = 1; r < cleanRows.length; r++) {
-    const row = cleanRows[r];
-    if (row.every((c) => !c)) continue;
-    const rowFormatted = colWidths
-      .map((width, colIdx) => (row[colIdx] || "").padEnd(width))
-      .join("  ")
-      .trimEnd();
-    formattedRows.push(rowFormatted);
+    if (colCount === 2) {
+      const key = formatInlineHtml(cleanCellText(row[0] || ""));
+      const val = formatInlineHtml(row[1] || "");
+      cardBlocks.push(`• <b>${key}:</b> ${val}`);
+    } else {
+      const primaryTitle = formatInlineHtml(cleanCellText(row[0] || (headerRow[0] ? `${headerRow[0]} ${r}` : `Item ${r}`)));
+      const lines: string[] = [`🔹 <b>${primaryTitle}</b>`];
+      for (let c = 1; c < colCount; c++) {
+        const colHeader = formatInlineHtml(cleanCellText(headerRow[c] || `Field ${c + 1}`));
+        const cellVal = formatInlineHtml(row[c] || "—");
+        lines.push(`  ▫️ <i>${colHeader}:</i> ${cellVal}`);
+      }
+      cardBlocks.push(lines.join("\n"));
+    }
   }
 
-  return `<pre><code class="language-text">${escapeHtml(formattedRows.join("\n"))}</code></pre>`;
+  return cardBlocks.join("\n\n");
 }
 
 function splitOversizedHtmlBlock(block: string, maxChars: number): string[] {
   const code = block.match(/^<pre><code( class="[^"]+")?>([\s\S]*)<\/code><\/pre>$/);
-  if (!code) return splitMessage(stripHtmlTags(block), maxChars).map(escapeHtml);
-  const open = `<pre><code${code[1] || ""}>`;
-  const close = "</code></pre>";
-  const contentLimit = Math.max(1, maxChars - open.length - close.length);
-  return splitMessage(code[2], contentLimit).map((part) => `${open}${part}${close}`);
+  if (code) {
+    const open = `<pre><code${code[1] || ""}>`;
+    const close = "</code></pre>";
+    const contentLimit = Math.max(1, maxChars - open.length - close.length);
+    return splitMessage(code[2], contentLimit).map((part) => `${open}${part}${close}`);
+  }
+  const quote = block.match(/^<blockquote>([\s\S]*)<\/blockquote>$/);
+  if (quote) {
+    const open = "<blockquote>";
+    const close = "</blockquote>";
+    const contentLimit = Math.max(1, maxChars - open.length - close.length);
+    return splitMessage(quote[1], contentLimit).map((part) => `${open}${part}${close}`);
+  }
+  return splitMessage(stripHtmlTags(block), maxChars).map(escapeHtml);
 }
 
 function stripHtmlTags(value: string): string {

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -6,14 +6,126 @@ import type { ChatId, InlineKeyboardMarkup, ReplyMarkup, TelegramUpdate } from "
 const API_ROOT = (token: string): string => `https://api.telegram.org/bot${token}`;
 export type TelegramParseMode = "HTML";
 
+export class TelegramApiError extends Error {
+  public constructor(
+    message: string,
+    public readonly statusCode?: number,
+    public readonly retryAfter?: number
+  ) {
+    super(message);
+    this.name = "TelegramApiError";
+  }
+}
+
+export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) return reject(new Error("Request cancelled"));
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new Error("Request cancelled"));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+export function isRetryableNetworkError(error: unknown): boolean {
+  if (!error) return false;
+  if (error instanceof TelegramApiError) {
+    if (error.statusCode === 429) return true;
+    if (error.statusCode && error.statusCode >= 500 && error.statusCode <= 599) return true;
+    return false;
+  }
+  if (error instanceof Error) {
+    if (error.name === "AbortError") return false;
+    const msg = error.message.toLowerCase();
+    if (
+      msg.includes("fetch failed") ||
+      msg.includes("econnreset") ||
+      msg.includes("econnrefused") ||
+      msg.includes("etimedout") ||
+      msg.includes("enotfound") ||
+      msg.includes("ehostunreach") ||
+      msg.includes("enetunreach") ||
+      msg.includes("eai_again") ||
+      msg.includes("socket hang up") ||
+      msg.includes("timeout") ||
+      msg.includes("und_err")
+    ) {
+      return true;
+    }
+    if (error.name === "TypeError" && msg.includes("fetch")) return true;
+  }
+  return false;
+}
+
+export interface RetryOptions {
+  maxRetries?: number;
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+  signal?: AbortSignal;
+}
+
+export async function executeWithRetry<T>(
+  operation: () => Promise<T>,
+  options: RetryOptions = {}
+): Promise<T> {
+  const maxRetries = options.maxRetries ?? 3;
+  const initialDelayMs = options.initialDelayMs ?? 500;
+  const maxDelayMs = options.maxDelayMs ?? 5000;
+  const signal = options.signal;
+
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
+    if (signal?.aborted) {
+      throw new Error("Request cancelled");
+    }
+
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+
+      if (signal?.aborted) {
+        throw error;
+      }
+
+      if (attempt === maxRetries || !isRetryableNetworkError(error)) {
+        throw error;
+      }
+
+      let delayMs = Math.min(maxDelayMs, initialDelayMs * 2 ** attempt) + Math.floor(Math.random() * 150);
+      if (error instanceof TelegramApiError && typeof error.retryAfter === "number" && error.retryAfter > 0) {
+        delayMs = Math.min(maxDelayMs, error.retryAfter * 1000);
+      }
+
+      await sleep(delayMs, signal);
+    }
+  }
+
+  throw lastError;
+}
+
 export class TelegramClient {
   private readonly root: string;
   public constructor(private readonly token: string) { this.root = API_ROOT(token); }
   public async call<T>(method: string, payload: Record<string, unknown> = {}, signal?: AbortSignal): Promise<T> {
-    const response = await fetch(`${this.root}/${method}`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(payload), signal });
-    const body = await response.json() as { ok: boolean; result?: T; description?: string };
-    if (!response.ok || !body.ok) throw new Error(`Telegram ${method} failed: ${body.description || response.status}`);
-    return body.result as T;
+    return executeWithRetry(async () => {
+      const response = await fetch(`${this.root}/${method}`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(payload), signal });
+      const body = await response.json() as { ok: boolean; result?: T; description?: string; error_code?: number; parameters?: { retry_after?: number } };
+      if (!response.ok || !body.ok) {
+        throw new TelegramApiError(
+          `Telegram ${method} failed: ${body.description || response.status}`,
+          body.error_code || response.status,
+          body.parameters?.retry_after
+        );
+      }
+      return body.result as T;
+    }, { signal });
   }
   public getUpdates(offset: number, signal?: AbortSignal): Promise<TelegramUpdate[]> { return this.call("getUpdates", { offset, timeout: 30, allowed_updates: ["message", "callback_query"] }, signal); }
   public sendMessage(chatId: ChatId, text: string, replyMarkup?: ReplyMarkup, parseMode?: TelegramParseMode): Promise<{ message_id: number }> {
@@ -49,66 +161,92 @@ export class TelegramClient {
   public answerCallbackQuery(callbackQueryId: string, text?: string): Promise<boolean> { return this.call<boolean>("answerCallbackQuery", { callback_query_id: callbackQueryId, ...(text ? { text } : {}) }); }
   public setMyCommands(commands: Array<{ command: string; description: string }>): Promise<boolean> { return this.call<boolean>("setMyCommands", { commands }); }
   public sendChatAction(chatId: ChatId, action = "typing"): Promise<boolean> { return this.call<boolean>("sendChatAction", { chat_id: chatId, action }); }
-  public async sendDocument(chatId: ChatId, filename: string, content: string): Promise<unknown> {
-    const form = new FormData(); form.append("chat_id", String(chatId)); form.append("document", new Blob([content], { type: "text/markdown" }), filename);
-    const response = await fetch(`${this.root}/sendDocument`, { method: "POST", body: form });
-    const body = await response.json() as { ok: boolean; result?: unknown; description?: string };
-    if (!response.ok || !body.ok) throw new Error(`Telegram sendDocument failed: ${body.description || response.status}`);
-    return body.result;
+  public async sendDocument(chatId: ChatId, filename: string, content: string, signal?: AbortSignal): Promise<unknown> {
+    return executeWithRetry(async () => {
+      const form = new FormData(); form.append("chat_id", String(chatId)); form.append("document", new Blob([content], { type: "text/markdown" }), filename);
+      const response = await fetch(`${this.root}/sendDocument`, { method: "POST", body: form, signal });
+      const body = await response.json() as { ok: boolean; result?: unknown; description?: string; error_code?: number; parameters?: { retry_after?: number } };
+      if (!response.ok || !body.ok) {
+        throw new TelegramApiError(
+          `Telegram sendDocument failed: ${body.description || response.status}`,
+          body.error_code || response.status,
+          body.parameters?.retry_after
+        );
+      }
+      return body.result;
+    }, { signal });
   }
-  public async sendPhoto(chatId: ChatId, photoPath: string | Buffer, caption?: string, parseMode?: TelegramParseMode, mimeType?: string, replyMarkup?: ReplyMarkup): Promise<unknown> {
-    const form = new FormData();
-    form.append("chat_id", String(chatId));
-    if (typeof photoPath === "string") {
-      const fileBuffer = await fs.readFile(photoPath);
-      const filename = path.basename(photoPath);
-      const ext = path.extname(photoPath).toLowerCase();
-      const detectedMime = ext === ".png" ? "image/png" : ext === ".webp" ? "image/webp" : "image/jpeg";
-      form.append("photo", new Blob([new Uint8Array(fileBuffer)], { type: detectedMime }), filename);
-    } else {
-      const mime = mimeType || "image/png";
-      form.append("photo", new Blob([new Uint8Array(photoPath)], { type: mime }), `image.${mime.split("/")[1] || "png"}`);
-    }
-    if (caption) {
-      form.append("caption", caption.slice(0, 1024));
-      if (parseMode) form.append("parse_mode", parseMode);
-    }
-    if (replyMarkup) {
-      form.append("reply_markup", JSON.stringify(replyMarkup));
-    }
-    const response = await fetch(`${this.root}/sendPhoto`, { method: "POST", body: form });
-    const body = await response.json() as { ok: boolean; result?: unknown; description?: string };
-    if (!response.ok || !body.ok) throw new Error(`Telegram sendPhoto failed: ${body.description || response.status}`);
-    return body.result;
+  public async sendPhoto(chatId: ChatId, photoPath: string | Buffer, caption?: string, parseMode?: TelegramParseMode, mimeType?: string, replyMarkup?: ReplyMarkup, signal?: AbortSignal): Promise<unknown> {
+    return executeWithRetry(async () => {
+      const form = new FormData();
+      form.append("chat_id", String(chatId));
+      if (typeof photoPath === "string") {
+        const fileBuffer = await fs.readFile(photoPath);
+        const filename = path.basename(photoPath);
+        const ext = path.extname(photoPath).toLowerCase();
+        const detectedMime = ext === ".png" ? "image/png" : ext === ".webp" ? "image/webp" : "image/jpeg";
+        form.append("photo", new Blob([new Uint8Array(fileBuffer)], { type: detectedMime }), filename);
+      } else {
+        const mime = mimeType || "image/png";
+        form.append("photo", new Blob([new Uint8Array(photoPath)], { type: mime }), `image.${mime.split("/")[1] || "png"}`);
+      }
+      if (caption) {
+        form.append("caption", caption.slice(0, 1024));
+        if (parseMode) form.append("parse_mode", parseMode);
+      }
+      if (replyMarkup) {
+        form.append("reply_markup", JSON.stringify(replyMarkup));
+      }
+      const response = await fetch(`${this.root}/sendPhoto`, { method: "POST", body: form, signal });
+      const body = await response.json() as { ok: boolean; result?: unknown; description?: string; error_code?: number; parameters?: { retry_after?: number } };
+      if (!response.ok || !body.ok) {
+        throw new TelegramApiError(
+          `Telegram sendPhoto failed: ${body.description || response.status}`,
+          body.error_code || response.status,
+          body.parameters?.retry_after
+        );
+      }
+      return body.result;
+    }, { signal });
   }
-  public async sendDocumentFile(chatId: ChatId, filePath: string, caption?: string, replyMarkup?: ReplyMarkup): Promise<unknown> {
-    const fileBuffer = await fs.readFile(filePath);
-    const form = new FormData();
-    form.append("chat_id", String(chatId));
-    form.append("document", new Blob([fileBuffer]), path.basename(filePath));
-    if (caption) {
-      form.append("caption", caption.slice(0, 1024));
-      form.append("parse_mode", "HTML");
-    }
-    if (replyMarkup) {
-      form.append("reply_markup", JSON.stringify(replyMarkup));
-    }
-    const response = await fetch(`${this.root}/sendDocument`, { method: "POST", body: form });
-    const body = await response.json() as { ok: boolean; result?: unknown; description?: string };
-    if (!response.ok || !body.ok) throw new Error(`Telegram sendDocument failed: ${body.description || response.status}`);
-    return body.result;
+  public async sendDocumentFile(chatId: ChatId, filePath: string, caption?: string, replyMarkup?: ReplyMarkup, signal?: AbortSignal): Promise<unknown> {
+    return executeWithRetry(async () => {
+      const fileBuffer = await fs.readFile(filePath);
+      const form = new FormData();
+      form.append("chat_id", String(chatId));
+      form.append("document", new Blob([new Uint8Array(fileBuffer)]), path.basename(filePath));
+      if (caption) {
+        form.append("caption", caption.slice(0, 1024));
+        form.append("parse_mode", "HTML");
+      }
+      if (replyMarkup) {
+        form.append("reply_markup", JSON.stringify(replyMarkup));
+      }
+      const response = await fetch(`${this.root}/sendDocument`, { method: "POST", body: form, signal });
+      const body = await response.json() as { ok: boolean; result?: unknown; description?: string; error_code?: number; parameters?: { retry_after?: number } };
+      if (!response.ok || !body.ok) {
+        throw new TelegramApiError(
+          `Telegram sendDocument failed: ${body.description || response.status}`,
+          body.error_code || response.status,
+          body.parameters?.retry_after
+        );
+      }
+      return body.result;
+    }, { signal });
   }
   public getFile(fileId: string): Promise<{ file_id: string; file_path?: string; file_size?: number }> {
     return this.call("getFile", { file_id: fileId });
   }
-  public async downloadFile(filePath: string, destination: string): Promise<string> {
-    const fileUrl = `https://api.telegram.org/file/bot${this.token}/${filePath}`;
-    const response = await fetch(fileUrl);
-    if (!response.ok) throw new Error(`Download file failed: ${response.statusText}`);
-    const buffer = Buffer.from(await response.arrayBuffer());
-    await fs.mkdir(path.dirname(destination), { recursive: true });
-    await fs.writeFile(destination, buffer);
-    return destination;
+  public async downloadFile(filePath: string, destination: string, signal?: AbortSignal): Promise<string> {
+    return executeWithRetry(async () => {
+      const fileUrl = `https://api.telegram.org/file/bot${this.token}/${filePath}`;
+      const response = await fetch(fileUrl, { signal });
+      if (!response.ok) throw new TelegramApiError(`Download file failed: ${response.statusText}`, response.status);
+      const buffer = Buffer.from(await response.arrayBuffer());
+      await fs.mkdir(path.dirname(destination), { recursive: true });
+      await fs.writeFile(destination, buffer);
+      return destination;
+    }, { signal });
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,10 @@ export interface ConversationSummary {
 
 export interface InFlightJob {
   prompt?: string;
+  kind?: "prompt" | "usage" | "credits" | "context";
+  imagePath?: string;
+  documentPath?: string;
+  documentName?: string;
   startedAt: number;
 }
 

--- a/test/pty-runner.test.ts
+++ b/test/pty-runner.test.ts
@@ -43,7 +43,7 @@ Five Hour Limit Remaining
   assert.doesNotMatch(parsed, /[█░▒▓]/);
 });
 
-test("parseUsageQuota consolidates identical shared quotas into Antigravity Quota (All Models)", () => {
+test("parseUsageQuota preserves separate Gemini and Claude & GPT sections even with identical quotas", () => {
   const sharedSample = `
 Models & Quota
 Account: dev@example.com
@@ -68,10 +68,10 @@ Refreshes in 4h 58m
 `;
 
   const parsed = parseUsageQuota(sharedSample);
-  assert.match(parsed, /<b>Antigravity Quota \(All Models\)<\/b>/);
+  assert.match(parsed, /<b>Gemini Models<\/b>/);
+  assert.match(parsed, /<b>Claude & GPT Models<\/b>/);
   assert.match(parsed, /Weekly Limit: <b>68% remaining<\/b> \(Refreshes in 120h 25m\)/);
   assert.match(parsed, /5-Hour Limit: <b>100% remaining<\/b> \(Refreshes in 4h 58m\)/);
-  assert.doesNotMatch(parsed, /Gemini Models/);
 });
 
 test("parseUsageQuota rejects startup / trust screen without quota data", () => {

--- a/test/telegram.test.ts
+++ b/test/telegram.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { escapeHtml, executeWithRetry, findReferencedMediaFiles, formatTelegramHtml, formatTelegramHtmlChunks, isRetryableNetworkError, splitMessage, splitPreformattedHtml, TelegramApiError, TelegramClient } from "../src/telegram.js";
+import { cleanLatexMath, escapeHtml, executeWithRetry, findReferencedMediaFiles, formatTelegramHtml, formatTelegramHtmlChunks, isRetryableNetworkError, sanitizeLatexExpressions, splitMessage, splitPreformattedHtml, TelegramApiError, TelegramClient } from "../src/telegram.js";
 import { createMainKeyboard } from "../src/keyboards.js";
 
 test("splitPreformattedHtml preserves HTML tags without double escaping", () => {
@@ -221,3 +221,42 @@ test("executeWithRetry aborts immediately if AbortSignal is cancelled", async ()
   }, /Request cancelled/);
   assert.equal(attempts, 0);
 });
+
+test("cleanLatexMath converts common LaTeX expressions, symbols, and formatting into clean Unicode text", () => {
+  assert.equal(cleanLatexMath("22\\,\\%"), "22 %");
+  assert.equal(cleanLatexMath("69{,}5\\,\\text{h}"), "69,5 h");
+  assert.equal(cleanLatexMath("0{,}316\\,\\%"), "0,316 %");
+  assert.equal(cleanLatexMath("\\rightarrow"), "→");
+  assert.equal(cleanLatexMath("\\approx 15\\,\\text{km}"), "≈ 15 km");
+  assert.equal(cleanLatexMath("E = mc^2"), "E = mc²");
+  assert.equal(cleanLatexMath("\\frac{a + b}{c}"), "(a + b)/(c)");
+  assert.equal(cleanLatexMath("\\sqrt{x^2 + y^2}"), "√(x² + y²)");
+  assert.equal(cleanLatexMath("\\alpha + \\beta \\le \\gamma"), "α + β ≤ γ");
+  assert.equal(cleanLatexMath("\\pm 5\\%"), "± 5%");
+});
+
+test("formatTelegramHtml cleans LaTeX math in LLM responses while preserving code and dollar amounts", () => {
+  const markdown = `### 2. Das 22%-Budget über ~70 Stunden
+Bei $22\\,\\%$ Restmenge über $69{,}5\\,\\text{h}$:
+* **Erlaubter Verbrauch:** maximal $0{,}316\\,\\%$ pro Stunde (bzw. $7{,}6\\,\\%$ pro Tag).
+
+| Scenario | Detail |
+| :--- | :--- |
+| **Sentry Mode** | Verbraucht ca. 5–10 % / Tag $\\rightarrow$ nach 2–3 Tagen leer. |
+
+Preis liegt bei $10 und $20.
+Inline code: \`$22\\,\\%\` und \`\\rightarrow\` bleiben unverändert.`;
+
+  const html = formatTelegramHtml(markdown);
+
+  assert.match(html, /<b>2\. Das 22%-Budget über ~70 Stunden<\/b>/);
+  assert.match(html, /Bei 22 % Restmenge über 69,5 h:/);
+  assert.match(html, /• <b>Erlaubter Verbrauch:<\/b> maximal 0,316 % pro Stunde \(bzw\. 7,6 % pro Tag\)\./);
+  assert.match(html, /Verbraucht ca\. 5–10 % \/ Tag → nach 2–3 Tagen leer\./);
+  assert.match(html, /Preis liegt bei \$10 und \$20\./);
+  assert.match(html, /<code>\$22\\,\\%<\/code>/);
+  assert.match(html, /<code>\\rightarrow<\/code>/);
+  assert.doesNotMatch(html, /Bei \$22/);
+  assert.doesNotMatch(html, /69\{,\}5/);
+});
+

--- a/test/telegram.test.ts
+++ b/test/telegram.test.ts
@@ -18,17 +18,12 @@ test("splitPreformattedHtml preserves HTML tags without double escaping", () => 
 
 test("splits Telegram messages near line boundaries", () => { const chunks = splitMessage("one\ntwo\nthree\nfour", 8); assert.deepEqual(chunks, ["one\ntwo", "three", "four"]); assert.ok(chunks.every((chunk) => chunk.length <= 8)); });
 
-test("builds a persistent new session, model, and verbose reply keyboard beside the input", () => {
+test("builds a persistent new session, model, and quota reply keyboard beside the input", () => {
   const keyboard = createMainKeyboard({ model: "gemini-3.6-flash-high", effort: "high", mode: "plan", sandbox: true, verbose: "detailed" });
-  assert.deepEqual(keyboard.keyboard, [["✨ New session", "🤖 Model", "📢 Verbose: det"]]);
+  assert.deepEqual(keyboard.keyboard, [["✨ New session", "🤖 Model", "📊 Quota"]]);
   assert.equal(keyboard.resize_keyboard, true);
   assert.equal(keyboard.is_persistent, true);
   assert.equal("inline_keyboard" in keyboard, false);
-});
-
-test("labels compact verbose in the persistent keyboard", () => {
-  const keyboard = createMainKeyboard({ model: null, effort: "medium", mode: "accept-edits", sandbox: true, verbose: "compact" });
-  assert.deepEqual(keyboard.keyboard, [["✨ New session", "🤖 Model", "📢 Verbose: comp"]]);
 });
 
 test("formats AGY Markdown-like responses as safe Telegram HTML", () => {

--- a/test/telegram.test.ts
+++ b/test/telegram.test.ts
@@ -42,7 +42,7 @@ test("formats AGY Markdown-like responses as safe Telegram HTML", () => {
   assert.doesNotMatch(html, /<script|<img/);
 });
 
-test("converts markdown tables to aligned monospace codeblocks in Telegram HTML", () => {
+test("converts markdown tables to mobile-friendly structured cards in Telegram HTML", () => {
   const markdown = `Here is a table:
 
 | Component / Service | Category | Status / Purpose |
@@ -55,9 +55,22 @@ End of table.`;
 
   const html = formatTelegramHtml(markdown);
   assert.match(html, /Here is a table:/);
-  assert.match(html, /<pre><code class="language-text">Component \/ Service\s+Category\s+Status \/ Purpose\n─+\nAPI Gateway\s+Networking\s+Entry point &amp; routing\nDatabase\s+Storage\s+State management &amp; logs\nWorker Node\s+Compute\s+Background job processor<\/code><\/pre>/);
+  assert.match(html, /🔹 <b>API Gateway<\/b>/);
+  assert.match(html, /▫️ <i>Category:<\/i> Networking/);
+  assert.match(html, /▫️ <i>Status \/ Purpose:<\/i> Entry point &amp; routing/);
   assert.match(html, /End of table\./);
-  assert.doesNotMatch(html, /\| \*\*API Gateway\*\*/);
+  assert.doesNotMatch(html, /<pre><code/);
+});
+
+test("converts 2-column markdown tables to clean key-value lists in Telegram HTML", () => {
+  const markdown = `| Key | Value |
+| :--- | :--- |
+| **CPU** | 8 Cores |
+| **RAM** | 16 GB |`;
+
+  const html = formatTelegramHtml(markdown);
+  assert.match(html, /• <b>CPU:<\/b> 8 Cores/);
+  assert.match(html, /• <b>RAM:<\/b> 16 GB/);
 });
 
 test("keeps long responses formatted while chunking under Telegram limits", () => {
@@ -114,5 +127,29 @@ test("formatTelegramHtmlChunks cleans local image markdown paths and formats cap
   assert.ok(!chunks[0].includes("/tmp/another.jpg"));
   assert.ok(chunks[0].includes("🖼 <i>Henrik mit Führerausweis</i>"));
   assert.ok(chunks[0].includes('🖼 <a href="https://example.com/chart.png">Chart</a>'));
+});
+
+test("formats blockquotes and GitHub-style alerts into native Telegram blockquotes", () => {
+  const markdown = "> [!TIP]\n> This is a helpful tip\n> with multiple lines\n\n> [!WARNING]\n> High battery temperature\n\n> Standard quoted text";
+  const html = formatTelegramHtml(markdown);
+  assert.ok(html.includes("<blockquote>💡 <b>Tip</b>\nThis is a helpful tip\nwith multiple lines</blockquote>"));
+  assert.ok(html.includes("<blockquote>⚠️ <b>Warning</b>\nHigh battery temperature</blockquote>"));
+  assert.ok(html.includes("<blockquote>Standard quoted text</blockquote>"));
+});
+
+test("formats interactive checkboxes and hierarchical nested lists", () => {
+  const markdown = "- [ ] Pending task\n- [x] Completed task\n- Top level bullet\n  - Sub bullet level 2\n    - Deep bullet level 3";
+  const html = formatTelegramHtml(markdown);
+  assert.match(html, /⬜ Pending task/);
+  assert.match(html, /✅ Completed task/);
+  assert.match(html, /• Top level bullet/);
+  assert.match(html, /  ▫️ Sub bullet level 2/);
+  assert.match(html, /    – Deep bullet level 3/);
+});
+
+test("formats markdown horizontal dividers into clean unicode dividers", () => {
+  const markdown = "Section 1\n\n---\n\nSection 2";
+  const html = formatTelegramHtml(markdown);
+  assert.match(html, /Section 1\n\n───────────────\n\nSection 2/);
 });
 

--- a/test/telegram.test.ts
+++ b/test/telegram.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { escapeHtml, findReferencedMediaFiles, formatTelegramHtml, formatTelegramHtmlChunks, splitMessage, splitPreformattedHtml } from "../src/telegram.js";
+import { escapeHtml, executeWithRetry, findReferencedMediaFiles, formatTelegramHtml, formatTelegramHtmlChunks, isRetryableNetworkError, splitMessage, splitPreformattedHtml, TelegramApiError, TelegramClient } from "../src/telegram.js";
 import { createMainKeyboard } from "../src/keyboards.js";
 
 test("splitPreformattedHtml preserves HTML tags without double escaping", () => {
@@ -115,4 +115,79 @@ test("formatTelegramHtmlChunks cleans local image markdown paths and formats cap
   assert.ok(chunks[0].includes("🖼 <i>Henrik mit Führerausweis</i>"));
   assert.ok(chunks[0].includes('🖼 <a href="https://example.com/chart.png">Chart</a>'));
 });
+
+test("isRetryableNetworkError identifies transient network failures and 5xx / 429 errors", () => {
+  assert.equal(isRetryableNetworkError(new TypeError("fetch failed")), true);
+  assert.equal(isRetryableNetworkError(new Error("read ECONNRESET")), true);
+  assert.equal(isRetryableNetworkError(new Error("connect ETIMEDOUT")), true);
+  assert.equal(isRetryableNetworkError(new Error("getaddrinfo ENOTFOUND api.telegram.org")), true);
+  assert.equal(isRetryableNetworkError(new Error("socket hang up")), true);
+  assert.equal(isRetryableNetworkError(new TelegramApiError("Bad Gateway", 502)), true);
+  assert.equal(isRetryableNetworkError(new TelegramApiError("Gateway Timeout", 504)), true);
+  assert.equal(isRetryableNetworkError(new TelegramApiError("Too Many Requests", 429, 5)), true);
+
+  // Non-retryable
+  assert.equal(isRetryableNetworkError(new TelegramApiError("Bad Request: chat not found", 400)), false);
+  assert.equal(isRetryableNetworkError(new TelegramApiError("Forbidden: bot was blocked by the user", 403)), false);
+  assert.equal(isRetryableNetworkError(new Error("Something arbitrary")), false);
+});
+
+test("executeWithRetry succeeds on first attempt without retrying", async () => {
+  let attempts = 0;
+  const result = await executeWithRetry(async () => {
+    attempts += 1;
+    return "success";
+  }, { initialDelayMs: 5 });
+  assert.equal(result, "success");
+  assert.equal(attempts, 1);
+});
+
+test("executeWithRetry retries on transient network error (fetch failed) and succeeds", async () => {
+  let attempts = 0;
+  const result = await executeWithRetry(async () => {
+    attempts += 1;
+    if (attempts < 3) {
+      throw new TypeError("fetch failed");
+    }
+    return "recovered";
+  }, { maxRetries: 3, initialDelayMs: 5 });
+  assert.equal(result, "recovered");
+  assert.equal(attempts, 3);
+});
+
+test("executeWithRetry throws immediately on non-retryable error without retrying", async () => {
+  let attempts = 0;
+  await assert.rejects(async () => {
+    await executeWithRetry(async () => {
+      attempts += 1;
+      throw new TelegramApiError("Bad Request: message is not modified", 400);
+    }, { maxRetries: 3, initialDelayMs: 5 });
+  }, /message is not modified/);
+  assert.equal(attempts, 1);
+});
+
+test("executeWithRetry stops after maxRetries if network error persists", async () => {
+  let attempts = 0;
+  await assert.rejects(async () => {
+    await executeWithRetry(async () => {
+      attempts += 1;
+      throw new TypeError("fetch failed");
+    }, { maxRetries: 2, initialDelayMs: 5 });
+  }, /fetch failed/);
+  assert.equal(attempts, 3); // initial attempt + 2 retries
+});
+
+test("executeWithRetry aborts immediately if AbortSignal is cancelled", async () => {
+  const controller = new AbortController();
+  controller.abort();
+  let attempts = 0;
+  await assert.rejects(async () => {
+    await executeWithRetry(async () => {
+      attempts += 1;
+      return "done";
+    }, { signal: controller.signal, initialDelayMs: 5 });
+  }, /Request cancelled/);
+  assert.equal(attempts, 0);
+});
+
 


### PR DESCRIPTION
## Summary
Preserves the dual-section quota structure in Telegram for **Gemini Models** and **Claude & GPT Models**, matching AGY's native TUI output.

### Problem
Previously:
1. When both model pools had identical quota percentages, they were consolidated into a single generic pool.
2. Leftover text from TUI autocomplete suggestions (containing model names like Gemini/Claude) could prematurely trigger the section regexes before the actual `Models & Quota` panel, causing the Gemini section to be skipped and Claude section to misread limits.

### Solution
- Isolate the actual `Models & Quota` command panel from preceding TUI / prompt noise before parsing.
- Retain explicit, separate sections for **Gemini Models** and **Claude & GPT Models** in the parsed Telegram message.
- Update tests to verify distinct sections and avoid premature regex matches.
