### PR TITLE
fix(process-cleanup): terminate full process group and descendants on…

### DIFF
--- a/src/agy-runner.ts
+++ b/src/agy-runner.ts
@@ -151,15 +151,21 @@ export function runAgyCommand(config: AgyConfig, commandArgs: string[], timeoutM
     child.stderr.on("data", (chunk: Buffer) => {
       if (stderr.length < 4000) stderr += chunk.toString();
     });
-    child.on("error", (error) => finish(() => reject(error)));
-    child.on("close", (code, signal) => finish(() => {
-      if (code !== 0) {
-        const detail = stderr.trim().replace(/\s+/g, " ").slice(0, 1000);
-        reject(new Error(`AGY command exited with ${code ?? signal}${detail ? `: ${detail}` : ""}`));
-        return;
-      }
-      resolve(stdout.trim() || stderr.trim() || "AGY returned no output.");
-    }));
+    child.on("error", (error) => {
+      stop();
+      finish(() => reject(error));
+    });
+    child.on("close", (code, signal) => {
+      stop();
+      finish(() => {
+        if (code !== 0) {
+          const detail = stderr.trim().replace(/\s+/g, " ").slice(0, 1000);
+          reject(new Error(`AGY command exited with ${code ?? signal}${detail ? `: ${detail}` : ""}`));
+          return;
+        }
+        resolve(stdout.trim() || stderr.trim() || "AGY returned no output.");
+      });
+    });
   });
 }
 
@@ -366,8 +372,12 @@ export function runAgy(config: AgyConfig, prompt: string, conversationId: string
       pendingLine += text; const lines = pendingLine.split(/\r?\n/); pendingLine = lines.pop() || ""; lines.forEach(emit);
     });
     child.stderr.on("data", (chunk: Buffer) => { if (stderr.length < 4000) stderr += chunk.toString(); });
-    child.on("error", (error) => finish(reject as (value: never) => void, error as never));
+    child.on("error", (error) => {
+      stop(true);
+      finish(reject as (value: never) => void, error as never);
+    });
     child.on("close", (code, signalName) => {
+      stop(true);
       if (outputFormat === "stream-json") emit(pendingLine);
       if (timedOut) return finish(reject as (value: never) => void, new Error(`AGY timed out after ${config.timeoutMs}ms`) as never);
       if (outputLimited) return finish(reject as (value: never) => void, new Error(`AGY output exceeded ${config.maxOutputBytes} bytes`) as never);

--- a/src/pty-runner.ts
+++ b/src/pty-runner.ts
@@ -371,12 +371,26 @@ try:
                 break
 finally:
     try:
-        os.kill(pid, signal.SIGTERM)
-        time.sleep(0.1)
-        os.kill(pid, signal.SIGKILL)
+        pgid = os.getpgid(pid)
+        os.killpg(pgid, signal.SIGTERM)
+    except Exception:
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except Exception:
+            pass
+    time.sleep(0.1)
+    try:
+        pgid = os.getpgid(pid)
+        os.killpg(pgid, signal.SIGKILL)
+    except Exception:
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except Exception:
+            pass
+    try:
+        os.close(master)
     except Exception:
         pass
-    os.close(master)
     try:
         os.waitpid(pid, 0)
     except Exception:


### PR DESCRIPTION
## Summary
- **PTY Runner (`src/pty-runner.ts`)**: Replaced direct single-PID `os.kill` calls in the Python PTY runner `finally` block with `os.killpg(pgid, ...)` using the process group ID. This ensures any child or grandchild processes spawned during interactive sessions are cleanly terminated when the PTY session closes, times out, or receives an abort signal.
- **AGY Runner (`src/agy-runner.ts`)**: Added explicit calls to `stop()` / `stop(true)` on `child.on('error')` and `child.on('close')`. This guarantees detached process trees and fallback unref timers are torn down immediately on exit or stream failure.

## Motivation
Previously, terminating an interactive PTY or background AGY runner process could leave detached descendant processes running in the background, consuming CPU and memory.

## Verification
- Unit test suite passes: `npm test` (120/120 tests pass).
- Smoke tests verify process groups are killed and reject promises on abort signal.
