### PR TITLE
feat(lifecycle): offer interactive inline retry button for interrupte…

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -11,14 +11,20 @@ import { enqueueJob } from "./usecases/enqueue.js";
 import { runPromptJob } from "./usecases/prompt-job.js";
 import { restartNoticePath } from "./usecases/self-update.js";
 import { handleUpdate } from "./router/updates.js";
-import type { TelegramUpdate } from "./types.js";
+import { button } from "./ui/inline-keyboards.js";
+import type { InFlightJob, InlineKeyboardMarkup, TelegramUpdate } from "./types.js";
 
 /**
  * Completes the service graph: creates the job queue wired to the prompt use
  * case and the cancellation hook that aborts in-flight AGY processes.
  */
 export function createAppServices(base: BaseServices): AppContext {
-  const services = { ...base, controllers: new Map<string, AbortController>(), pendingDangerousCommands: new Map<string, string[]>() } as AppContext;
+  const services = {
+    ...base,
+    controllers: new Map<string, AbortController>(),
+    pendingDangerousCommands: new Map<string, string[]>(),
+    pendingInterruptedJobs: new Map<string, InFlightJob>(),
+  } as AppContext;
   const queue = new JobQueue(base.config.queue.maxSize, (job, isCancelled) => runPromptJob(services, job, isCancelled), {
     onCancel: (chatId) => {
       services.controllers.get(controllerKey("prompt", chatId))?.abort();
@@ -43,7 +49,7 @@ const BOT_COMMANDS: Array<{ command: string; description: string }> = [
   { command: "model", description: "Show or choose the model" },
   { command: "effort", description: "Show or change reasoning effort" },
   { command: "mode", description: "Show or change plan/edit mode" },
-  { command: "sandbox", description: "Show or change sandbox mode" },
+  { command: "sandbox", description: "Toggle AGY sandbox execution" },
   { command: "verbose", description: "Show or change verbose level (detailed, compact, silent)" },
   { command: "session", description: "Show session settings" },
   { command: "learn", description: "Learn reusable rules/skills from recent chat" },
@@ -104,21 +110,19 @@ export async function resumeInterruptedJobs(context: AppContext): Promise<void> 
     await context.state.clearAllInFlight();
     for (const [chatId, job] of Object.entries(interrupted)) {
       if (job.prompt || job.kind === "usage" || job.kind === "credits" || job.kind === "context") {
+        context.pendingInterruptedJobs.set(String(chatId), job);
         const promptSnippet = job.prompt ? ` (Prompt: <i>"${escapeHtml(job.prompt.slice(0, 60))}${job.prompt.length > 60 ? "..." : ""}"</i>)` : "";
+        const retryKeyboard: InlineKeyboardMarkup = {
+          inline_keyboard: [
+            [button("🔄 Retry Interrupted Job", "action:retry_interrupted")],
+          ],
+        };
         await context.telegram.sendMessage(
           chatId,
-          `⚡ <b>AGY Gateway restarted</b>\n\nYour previous request was interrupted by a restart${promptSnippet}.\n<i>Resuming execution now...</i>`,
-          createMainKeyboard(settingsFor(context, chatId)),
+          `⚡ <b>AGY Gateway restarted</b>\n\nYour previous request was interrupted by a service restart${promptSnippet}.\n<i>Click the button below to resume execution.</i>`,
+          retryKeyboard,
           "HTML"
         ).catch(() => undefined);
-
-        enqueueJob(context, chatId, {
-          kind: job.kind || "prompt",
-          prompt: job.prompt,
-          imagePath: job.imagePath,
-          documentPath: job.documentPath,
-          documentName: job.documentName,
-        });
       } else {
         await context.telegram.sendMessage(
           chatId,

--- a/src/context.ts
+++ b/src/context.ts
@@ -2,7 +2,7 @@ import type { ConversationDatabase } from "./db.js";
 import type { JobQueue } from "./queue.js";
 import type { StateStore } from "./state.js";
 import type { TelegramClient } from "./telegram.js";
-import type { AppConfig, ChatId } from "./types.js";
+import type { AppConfig, ChatId, InFlightJob } from "./types.js";
 
 /**
  * Explicit dependency graph of the running bot. Every handler and use case
@@ -16,6 +16,7 @@ export interface AppContext {
   queue: JobQueue;
   readonly controllers: Map<string, AbortController>;
   readonly pendingDangerousCommands: Map<string, string[]>;
+  readonly pendingInterruptedJobs: Map<string, InFlightJob>;
 }
 
 export interface BaseServices {

--- a/src/router/callback-parser.ts
+++ b/src/router/callback-parser.ts
@@ -14,6 +14,7 @@ export type CallbackAction =
   | { kind: "setdefault" }
   | { kind: "update-bot" }
   | { kind: "new-session" }
+  | { kind: "retry-interrupted" }
   | { kind: "cancel" }
   | { kind: "cli"; command: string }
   | { kind: "toggle"; option: string }
@@ -40,6 +41,7 @@ export function parseCallbackAction(data: string): CallbackAction | null {
   if (data === "action:setdefault") return { kind: "setdefault" };
   if (data === "action:update_bot") return { kind: "update-bot" };
   if (data === "action:new") return { kind: "new-session" };
+  if (data === "action:retry_interrupted") return { kind: "retry-interrupted" };
   if (data === "action:cancel") return { kind: "cancel" };
   if (data.startsWith("cli:")) return { kind: "cli", command: data.slice("cli:".length) };
   if (data.startsWith("toggle:")) return { kind: "toggle", option: data.slice("toggle:".length) };
@@ -63,6 +65,7 @@ export function serializeCallbackData(action: CallbackAction): string {
     case "setdefault": return "action:setdefault";
     case "update-bot": return "action:update_bot";
     case "new-session": return "action:new";
+    case "retry-interrupted": return "action:retry_interrupted";
     case "cancel": return "action:cancel";
     case "cli": return `cli:${action.command}`;
     case "toggle": return `toggle:${action.option}`;

--- a/src/router/callbacks.ts
+++ b/src/router/callbacks.ts
@@ -67,6 +67,23 @@ export async function handleCallback(context: AppContext, callback: TelegramCall
       await context.telegram.editMessageText(chatId, messageId, sessionInfoHtml(context, chatId), { inline_keyboard: [[button("‹ Back to Menu", "menu:main")]] }, "HTML");
       await context.telegram.sendMessage(chatId, "Controls ready.", createMainKeyboard(settingsFor(context, chatId)));
       return;
+    case "retry-interrupted": {
+      const job = context.pendingInterruptedJobs.get(String(chatId));
+      if (!job) {
+        await context.telegram.editMessageText(chatId, messageId, "ℹ️ <i>No interrupted job found or already executed.</i>", undefined, "HTML").catch(() => undefined);
+        return;
+      }
+      context.pendingInterruptedJobs.delete(String(chatId));
+      await context.telegram.editMessageText(chatId, messageId, "🔄 <b>Retrying interrupted job...</b>", undefined, "HTML").catch(() => undefined);
+      enqueueJob(context, chatId, {
+        kind: job.kind || "prompt",
+        prompt: job.prompt,
+        imagePath: job.imagePath,
+        documentPath: job.documentPath,
+        documentName: job.documentName,
+      });
+      return;
+    }
     case "cancel": {
       const result = context.queue.cancelForChat(chatId);
       await context.telegram.editMessageText(chatId, messageId, `Cancelled: ${result.removed} queued, active=${result.activeCancelled ? "yes" : "no"}.`, { inline_keyboard: [] });

--- a/test/callback-parser.test.ts
+++ b/test/callback-parser.test.ts
@@ -19,6 +19,7 @@ test("callback parser decodes every wire format the keyboards emit", () => {
   assert.deepEqual(parseCallbackAction("action:setdefault"), { kind: "setdefault" });
   assert.deepEqual(parseCallbackAction("action:update_bot"), { kind: "update-bot" });
   assert.deepEqual(parseCallbackAction("action:new"), { kind: "new-session" });
+  assert.deepEqual(parseCallbackAction("action:retry_interrupted"), { kind: "retry-interrupted" });
   assert.deepEqual(parseCallbackAction("action:cancel"), { kind: "cancel" });
   assert.deepEqual(parseCallbackAction("cli:version"), { kind: "cli", command: "version" });
   assert.deepEqual(parseCallbackAction("toggle:disable-slash"), { kind: "toggle", option: "disable-slash" });
@@ -49,6 +50,7 @@ test("callback parser/serializer round-trips without loss", () => {
     "action:setdefault",
     "action:update_bot",
     "action:new",
+    "action:retry_interrupted",
     "action:cancel",
     "cli:update",
     "toggle:continue",

--- a/test/handlers.test.ts
+++ b/test/handlers.test.ts
@@ -492,3 +492,38 @@ test("createAppServices wires queue cancellation to controller abortion", async 
     harness.cleanup();
   }
 });
+
+test("lifecycle: interrupted jobs offer interactive retry button and resume on tap", async () => {
+  const harness = createHarness();
+  const ctx = asAppContext(harness);
+  try {
+    const { resumeInterruptedJobs } = await import("../src/bot.js");
+    const { handleCallback } = await import("../src/router/callbacks.js");
+
+    await ctx.state.setInFlight(777, { kind: "prompt", prompt: "heavy compute task" });
+    assert.ok(ctx.state.inFlight["777"]);
+
+    await resumeInterruptedJobs(ctx);
+
+    assert.equal(Object.keys(ctx.state.inFlight).length, 0, "in-flight state should be cleared");
+    assert.equal(ctx.pendingInterruptedJobs.get("777")?.prompt, "heavy compute task", "job held in pendingInterruptedJobs");
+
+    const sent = harness.telegram.calls.filter((c) => c.method === "sendMessage");
+    assert.equal(sent.length, 1);
+    assert.match(sent[0].payload.text as string, /AGY Gateway restarted/);
+    assert.match(sent[0].payload.text as string, /heavy compute task/);
+
+    const keyboard = sent[0].payload.reply_markup as import("../src/types.js").InlineKeyboardMarkup;
+    assert.equal(keyboard.inline_keyboard[0][0].callback_data, "action:retry_interrupted");
+
+    // Click the retry button using an authorized user
+    await handleCallback(ctx, callbackUpdate("action:retry_interrupted", 777, 888, 111));
+
+    assert.equal(ctx.pendingInterruptedJobs.has("777"), false, "job cleared from pending on retry");
+    assert.equal(harness.capturedJobs.filter((j) => j.prompt === "heavy compute task").length, 1, "job enqueued on click");
+    assert.match(harness.telegram.editedTexts().at(-1) || "", /Retrying interrupted job/);
+  } finally {
+    harness.cleanup();
+  }
+});
+

--- a/test/helpers/fixtures.ts
+++ b/test/helpers/fixtures.ts
@@ -6,7 +6,7 @@ import { loadConfig } from "../../src/config.js";
 import { ConversationDatabase } from "../../src/db.js";
 import { JobQueue, type QueueJob } from "../../src/queue.js";
 import { StateStore } from "../../src/state.js";
-import type { AppConfig, TelegramUpdate } from "../../src/types.js";
+import type { AppConfig, InFlightJob, TelegramUpdate } from "../../src/types.js";
 import { FakeTelegramClient } from "./fake-telegram.js";
 
 export interface TestServices {
@@ -17,6 +17,7 @@ export interface TestServices {
   queue: JobQueue;
   controllers: Map<string, AbortController>;
   pendingDangerousCommands: Map<string, string[]>;
+  pendingInterruptedJobs: Map<string, InFlightJob>;
 }
 
 const BASE_ENV: Record<string, string> = {
@@ -67,6 +68,7 @@ export function createHarness(env: Record<string, string> = {}): Harness {
   const telegram = new FakeTelegramClient();
   const controllers = new Map<string, AbortController>();
   const pendingDangerousCommands = new Map<string, string[]>();
+  const pendingInterruptedJobs = new Map<string, InFlightJob>();
   const capturedJobs: Harness["capturedJobs"] = [];
 
   let currentWorker: (job: QueueJob, isCancelled: () => boolean) => Promise<void> = (job, isCancelled) =>
@@ -95,6 +97,7 @@ export function createHarness(env: Record<string, string> = {}): Harness {
     queue,
     controllers,
     pendingDangerousCommands,
+    pendingInterruptedJobs,
     capturedJobs,
     setWorker(worker) {
       currentWorker = worker;


### PR DESCRIPTION
## Summary
- **Restart UX (`src/bot.ts`)**: When the gateway restarts while requests were in-flight, instead of automatically re-enqueuing the jobs (which can cause endless restart/crash loops if a prompt triggers a fatal crash on boot), the bot stores the interrupted jobs in a pending map (`pendingInterruptedJobs`) and notifies the user with an interactive inline button `🔄 Retry Interrupted Job` (`action:retry_interrupted`).
- **Callback Router (`src/router/callback-parser.ts` & `src/router/callbacks.ts`)**: Added typed parsing and handling for `action:retry_interrupted`. When tapped by an authorized user, it confirms the retry via an updated status message and enqueues the original job with its exact parameters (prompt, image, document).
- **Test Coverage (`test/handlers.test.ts` & `test/callback-parser.test.ts`)**: Added comprehensive tests verifying state clearing, button emission, callback parsing round-trip, and job resumption upon user interaction.

## Motivation
Automatic resumption on restart is risky if an unhandled error or malformed payload caused the service crash in the first place. Offering an explicit one-tap retry button gives control back to the user while keeping recovery frictionless.

## Verification
- Unit test suite passes: `npm test` (121/121 tests pass).
- Added lifecycle regression test covering interrupted job storage and interactive resumption.
