### PR TITLE
feat(ui): add stop quickbutton and /stop command alias (#16)

### DIFF
--- a/src/keyboards.ts
+++ b/src/keyboards.ts
@@ -4,7 +4,7 @@ import type { ReplyKeyboardMarkup, SessionSettings } from "./types.js";
 export function createMainKeyboard(_settings?: SessionSettings): ReplyKeyboardMarkup {
   return {
     keyboard: [
-      ["✨ New session", "🤖 Model", "📊 Quota"],
+      ["✨ New", "🛑 Stop", "🤖 Model", "📊 Quota"],
     ],
     resize_keyboard: true,
     is_persistent: true,

--- a/src/router/commands.ts
+++ b/src/router/commands.ts
@@ -339,7 +339,7 @@ command("/status")(async ({ context, chatId }) => {
   await reply(context, chatId, `Status: ${status.active ? `running (${status.active.id})` : "idle"}\nQueued for this chat: ${status.queued}\nTotal queued: ${status.totalQueued}`, createMainKeyboard(settingsFor(context, chatId)));
 });
 
-command("/cancel", "/kill")(async ({ context, chatId }) => {
+command("/cancel", "/kill", "/stop")(async ({ context, chatId }) => {
   context.pendingDangerousCommands.delete(String(chatId));
   context.controllers.get(controllerKey("prompt", chatId))?.abort();
   context.controllers.get(controllerKey("custom", chatId))?.abort();

--- a/src/router/updates.ts
+++ b/src/router/updates.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { AppContext } from "../context.js";
+import { controllerKey } from "../context.js";
 import { parseCommandArgs } from "../agy-runner.js";
 import { createMainKeyboard } from "../keyboards.js";
 import { settingsFor } from "../domain/settings.js";
@@ -76,6 +77,14 @@ export async function handleUpdate(context: AppContext, update: TelegramUpdate):
     if (buttonText === "✨ New session" || buttonText === "✨ New") {
       await context.state.resetSession(message.chat.id);
       await replyWithHtml(context, message.chat.id, sessionInfoHtml(context, message.chat.id), createMainKeyboard(settingsFor(context, message.chat.id)));
+      return;
+    }
+    if (buttonText === "🛑 Stop" || buttonText === "🛑 Cancel" || buttonText === "Stop" || buttonText === "Cancel") {
+      context.pendingDangerousCommands.delete(String(message.chat.id));
+      context.controllers.get(controllerKey("prompt", message.chat.id))?.abort();
+      context.controllers.get(controllerKey("custom", message.chat.id))?.abort();
+      const result = context.queue.cancelForChat(message.chat.id);
+      await reply(context, message.chat.id, `⛔ Cancelled: ${result.removed} queued job(s) removed, active AGY process terminated.`, createMainKeyboard(settingsFor(context, message.chat.id)));
       return;
     }
     if (buttonText === "🤖 Model") { await reply(context, message.chat.id, "Select a model:", modelKeyboard(context, message.chat.id)); return; }

--- a/test/handlers.test.ts
+++ b/test/handlers.test.ts
@@ -343,7 +343,7 @@ test("queue feedback: position announcements and queue-full notice", async () =>
   }
 });
 
-test("/cancel aborts in-flight controllers and clears pending dangerous commands", async () => {
+test("/cancel and /stop abort in-flight controllers and clear pending dangerous commands", async () => {
   const harness = createHarness();
   const ctx = asAppContext(harness);
   try {
@@ -351,10 +351,16 @@ test("/cancel aborts in-flight controllers and clears pending dangerous commands
     ctx.controllers.set(`custom:${777}`, controller);
     ctx.pendingDangerousCommands.set("777", ["update"]);
 
-    await handleCommand(ctx, textUpdate(777, "").message!, "/cancel", []);
+    await handleCommand(ctx, textUpdate(777, "").message!, "/stop", []);
 
     assert.equal(controller.signal.aborted, true);
     assert.equal(ctx.pendingDangerousCommands.has("777"), false);
+    assert.equal(harness.telegram.sentTexts().at(-1), "⛔ Cancelled: 0 queued job(s) removed, active AGY process terminated.");
+
+    const promptController = new AbortController();
+    ctx.controllers.set(`prompt:${777}`, promptController);
+    await handleUpdate(ctx, textUpdate(777, "🛑 Stop"));
+    assert.equal(promptController.signal.aborted, true);
     assert.equal(harness.telegram.sentTexts().at(-1), "⛔ Cancelled: 0 queued job(s) removed, active AGY process terminated.");
   } finally {
     harness.cleanup();

--- a/test/helpers/original-commands.ts
+++ b/test/helpers/original-commands.ts
@@ -8,7 +8,7 @@ export const ORIGINAL_COMMANDS: string[] = [
   "/models", "/model", "/effort", "/mode", "/sandbox", "/verbose", "/agent", "/project", "/add-dir",
   "/output-format", "/json-schema", "/log-file", "/print-timeout", "/resume", "/sessions", "/continue",
   "/new-project", "/disable-slash-commands", "/agents", "/changelog", "/plugins", "/cli-help", "/version",
-  "/session", "/usage", "/quota", "/credits", "/context", "/tokens", "/status", "/cancel", "/kill",
+  "/session", "/usage", "/quota", "/credits", "/context", "/tokens", "/status", "/cancel", "/kill", "/stop",
   "/learn", "/compact", "/agy-confirm",
 ];
 

--- a/test/telegram.test.ts
+++ b/test/telegram.test.ts
@@ -18,9 +18,9 @@ test("splitPreformattedHtml preserves HTML tags without double escaping", () => 
 
 test("splits Telegram messages near line boundaries", () => { const chunks = splitMessage("one\ntwo\nthree\nfour", 8); assert.deepEqual(chunks, ["one\ntwo", "three", "four"]); assert.ok(chunks.every((chunk) => chunk.length <= 8)); });
 
-test("builds a persistent new session, model, and quota reply keyboard beside the input", () => {
+test("builds a persistent new session, stop, model, and quota reply keyboard beside the input", () => {
   const keyboard = createMainKeyboard({ model: "gemini-3.6-flash-high", effort: "high", mode: "plan", sandbox: true, verbose: "detailed" });
-  assert.deepEqual(keyboard.keyboard, [["✨ New session", "🤖 Model", "📊 Quota"]]);
+  assert.deepEqual(keyboard.keyboard, [["✨ New", "🛑 Stop", "🤖 Model", "📊 Quota"]]);
   assert.equal(keyboard.resize_keyboard, true);
   assert.equal(keyboard.is_persistent, true);
   assert.equal("inline_keyboard" in keyboard, false);


### PR DESCRIPTION
### Summary

Adds a dedicated **`🛑 Stop`** button to the persistent main reply keyboard and registers `/stop` as a native alias to `/cancel` and `/kill`.

### Motivation & Problem
While running long-running tasks or streaming multi-step prompt executions, users frequently need a quick 1-tap mechanism on mobile to immediately interrupt the active AGY process without having to open the menu or type `/cancel`.

### Changes

1. **Persistent Reply Keyboard (`src/keyboards.ts`)**:
   - Updated layout to a clean 4-button row: `["✨ New", "🛑 Stop", "🤖 Model", "📊 Quota"]`.
   - Shortened `"✨ New session"` to `"✨ New"` to ensure optimal spacing and alignment on mobile screens.

2. **Stop Action Handler (`src/router/updates.ts`)**:
   - Added instant handling for `🛑 Stop` (and variants `🛑 Cancel`, `Stop`, `Cancel`).
   - Immediately aborts in-flight execution controllers (`prompt` and `custom`), clears pending dangerous commands, and purges remaining queued jobs for the chat.

3. **Command Registry Alias (`src/router/commands.ts`)**:
   - Added `/stop` as an alias alongside `/cancel` and `/kill`.

4. **Testing & Quality Assurance**:
   - Updated keyboard and command-parity unit tests.
   - Added unit test coverage for `/stop` and the `🛑 Stop` button abort flow.
   - All 122 tests passing (`npm test`).
   - Clean TypeScript compilation (`npm run build`).
   - Verified 0 secrets via Gitleaks.
