### PR TITLE
fix(markdown): handle nested code fences, preserve braces and improve chunk boundary split

### DIFF
--- a/src/telegram/markdown-renderer.ts
+++ b/src/telegram/markdown-renderer.ts
@@ -1,8 +1,23 @@
 export function splitMessage(text: string, maxChars: number): string[] {
   if (text.length <= maxChars) return [text];
-  const chunks: string[] = []; let rest = text;
-  while (rest.length > maxChars) { let cut = rest.lastIndexOf("\n", maxChars); if (cut < Math.floor(maxChars * 0.5)) cut = maxChars; chunks.push(rest.slice(0, cut)); rest = rest.slice(cut).replace(/^\n+/, ""); }
-  if (rest) chunks.push(rest); return chunks;
+  const chunks: string[] = [];
+  let rest = text;
+  while (rest.length > maxChars) {
+    let cut = rest.lastIndexOf("\n", maxChars);
+    if (cut < Math.floor(maxChars * 0.5)) {
+      const spaceCut = rest.lastIndexOf(" ", maxChars);
+      if (spaceCut >= Math.floor(maxChars * 0.5)) {
+        cut = spaceCut;
+      } else {
+        cut = maxChars;
+      }
+    }
+    chunks.push(rest.slice(0, cut));
+    rest = rest.slice(cut).replace(/^[\n\r]+/, "");
+    if (cut !== maxChars && rest.startsWith(" ")) rest = rest.slice(1);
+  }
+  if (rest) chunks.push(rest);
+  return chunks;
 }
 
 /** Splits pre-formatted HTML text without re-escaping HTML tags. */
@@ -76,28 +91,62 @@ function renderTelegramBlocks(text: string): string[] {
   const output: string[] = [];
   let codeLines: string[] | null = null;
   let codeLanguage = "";
+  let codeFenceLength = 0;
+  let nestedCodeDepth = 0;
+
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
-    const fence = line.match(/^\s*```\s*([\w+-]*)\s*$/);
-    if (fence) {
-      if (codeLines) {
-        const language = codeLanguage ? ` class="language-${escapeHtml(codeLanguage)}"` : "";
-        output.push(`<pre><code${language}>${escapeHtml(codeLines.join("\n"))}</code></pre>`);
-        codeLines = null;
-        codeLanguage = "";
-      } else {
-        if (output.length > 0 && output[output.length - 1] !== "") {
-          output.push("");
-        }
-        codeLines = [];
-        codeLanguage = fence[1] || "";
-      }
-      continue;
-    }
+
     if (codeLines) {
+      const isMarkdownBlock = codeLanguage === "markdown" || codeLanguage === "md";
+      const nestedOpenMatch = line.match(/^\s{0,3}(`{3,})\s*([\w+-]+)\s*$/);
+      if (isMarkdownBlock && nestedOpenMatch) {
+        nestedCodeDepth++;
+        codeLines.push(line);
+        continue;
+      }
+
+      const closeMatch = line.match(/^\s{0,3}(`{3,})\s*$/);
+      if (closeMatch) {
+        if (nestedCodeDepth > 0 && closeMatch[1].length < codeFenceLength) {
+          nestedCodeDepth--;
+          codeLines.push(line);
+          continue;
+        }
+
+        if (closeMatch[1].length >= codeFenceLength) {
+          if (nestedCodeDepth > 0) {
+            nestedCodeDepth--;
+            codeLines.push(line);
+            continue;
+          }
+
+          const language = codeLanguage ? ` class="language-${escapeHtml(codeLanguage)}"` : "";
+          output.push(`<pre><code${language}>${escapeHtml(codeLines.join("\n"))}</code></pre>`);
+          codeLines = null;
+          codeLanguage = "";
+          codeFenceLength = 0;
+          nestedCodeDepth = 0;
+          continue;
+        }
+      }
+
       codeLines.push(line);
       continue;
     }
+
+    const openFence = line.match(/^\s{0,3}(`{3,})\s*([\w+-]*)\s*$/);
+    if (openFence) {
+      if (output.length > 0 && output[output.length - 1] !== "") {
+        output.push("");
+      }
+      codeLines = [];
+      codeFenceLength = openFence[1].length;
+      codeLanguage = openFence[2] || "";
+      nestedCodeDepth = 0;
+      continue;
+    }
+
 
     // Preformatted HTML Blockquote with inner content sanitization
     if (line.match(/^\s*<blockquote(?:\s+expandable)?>/i)) {
@@ -507,8 +556,6 @@ export function cleanLatexMath(expr: string): string {
     if (GREEK_MAP[name]) return GREEK_MAP[name];
     return name;
   });
-
-  res = res.replace(/\{([^{}]+)\}/g, "$1");
 
   return res.trim().replace(/\s{2,}/g, " ");
 }

--- a/src/usecases/session-cleanup.ts
+++ b/src/usecases/session-cleanup.ts
@@ -3,17 +3,17 @@ import path from "node:path";
 import type { ChatId } from "../types.js";
 
 /**
- * Supprime les fichiers temporaires et images associés à une session Telegram spécifique.
+ * Removes temporary files and images associated with a specific Telegram session.
  */
 export async function cleanupSessionTempFiles(tempDir: string, chatId: ChatId): Promise<void> {
   const sessionDir = path.join(tempDir, `chat_${chatId}`);
   try {
     await fs.rm(sessionDir, { recursive: true, force: true });
   } catch {
-    // Dossier inexistant ignoré
+    // Ignore missing directory
   }
 
-  // Nettoyer également les fichiers résiduels à la racine du tempDir
+  // Also clean residual session files at the root of tempDir
   try {
     const entries = await fs.readdir(tempDir, { withFileTypes: true });
     for (const entry of entries) {
@@ -22,12 +22,12 @@ export async function cleanupSessionTempFiles(tempDir: string, chatId: ChatId): 
       }
     }
   } catch {
-    // Dossier temp inexistant ignoré
+    // Ignore missing temp directory
   }
 }
 
 /**
- * Supprime les fichiers et dossiers temporaires orphelins ou expirés (plus de 24h).
+ * Removes orphaned or expired temporary files and directories (older than 24h).
  */
 export async function cleanupStaleTempFiles(tempDir: string, maxAgeMs = 24 * 60 * 60 * 1000): Promise<void> {
   try {
@@ -46,10 +46,10 @@ export async function cleanupStaleTempFiles(tempDir: string, maxAgeMs = 24 * 60 
           }
         }
       } catch {
-        // Fichier déjà supprimé
+        // File already deleted
       }
     }
   } catch {
-    // Dossier inaccessible ignoré
+    // Ignore inaccessible directory
   }
 }

--- a/test/telegram.test.ts
+++ b/test/telegram.test.ts
@@ -300,3 +300,87 @@ Inline code: \`$22\\,\\%\` und \`\\rightarrow\` bleiben unverändert.`;
   assert.doesNotMatch(html, /69\{,\}5/);
 });
 
+test("formatTelegramHtml handles nested code fences without premature closure", () => {
+  const input = [
+    "```markdown",
+    "Here is an explanation:",
+    "#### 2. Pluggable Adapter Pattern",
+    "",
+    "```typescript",
+    "export interface TranscriptionResult {",
+    "  text: string;",
+    "  options?: { signal?: AbortSignal };",
+    "}",
+    "```",
+    "",
+    "Configured via environment variables.",
+    "```",
+  ].join("\n");
+
+  const html = formatTelegramHtml(input);
+  assert.ok(html.startsWith('<pre><code class="language-markdown">'));
+  assert.ok(html.endsWith("</code></pre>"));
+  assert.ok(html.includes("#### 2. Pluggable Adapter Pattern"));
+  assert.ok(html.includes("export interface TranscriptionResult"));
+  assert.ok(html.includes("options?: { signal?: AbortSignal };"));
+  assert.ok(html.includes("Configured via environment variables."));
+  const preCount = (html.match(/<pre>/g) || []).length;
+  assert.equal(preCount, 1);
+});
+
+test("formatTelegramHtml handles 4-backtick code fences enclosing 3-backtick fences", () => {
+  const input = [
+    "````markdown",
+    "Here is code:",
+    "```typescript",
+    "const ok = true;",
+    "```",
+    "````",
+  ].join("\n");
+
+  const html = formatTelegramHtml(input);
+  assert.ok(html.startsWith('<pre><code class="language-markdown">'));
+  assert.ok(html.endsWith("</code></pre>"));
+  assert.ok(html.includes("const ok = true;"));
+  const preCount = (html.match(/<pre>/g) || []).length;
+  assert.equal(preCount, 1);
+});
+
+test("formatTelegramHtml handles multiple sequential code blocks properly", () => {
+  const input = [
+    "```typescript",
+    "const a = 1;",
+    "```",
+    "",
+    "Normal text in between.",
+    "",
+    "```bash",
+    "npm test",
+    "```",
+  ].join("\n");
+
+  const html = formatTelegramHtml(input);
+  assert.ok(html.includes('<pre><code class="language-typescript">const a = 1;</code></pre>'));
+  assert.ok(html.includes("Normal text in between."));
+  assert.ok(html.includes('<pre><code class="language-bash">npm test</code></pre>'));
+  const preCount = (html.match(/<pre>/g) || []).length;
+  assert.equal(preCount, 2);
+});
+
+test("formatTelegramHtml preserves object and type curly braces in regular text", () => {
+  const input = "Set the options parameter to { timeoutMs: 5000, signal?: AbortSignal } for safety.";
+  const html = formatTelegramHtml(input);
+  assert.ok(html.includes("{ timeoutMs: 5000, signal?: AbortSignal }"));
+});
+
+test("splitMessage splits at word boundaries when newline is not available", () => {
+  const text = "transcode locally requires installing system-level ffmpeg and native C++ bindings for whisper.";
+  const chunks = splitMessage(text, 40);
+  assert.ok(chunks.length > 1);
+  for (const chunk of chunks) {
+    assert.ok(chunk.length <= 40);
+  }
+  assert.equal(chunks[0], "transcode locally requires installing");
+});
+
+


### PR DESCRIPTION
### Description

This PR resolves a formatting and inversion issue in the Telegram Markdown renderer when responses contain nested code fences (e.g. drafting Markdown notes or GitHub issues with internal code blocks), as well as two related rendering edge cases:

1. **Nested Code Fence Inversion Fix**:
   - Previously, `renderTelegramBlocks` used a naive binary toggle (`codeLines !== null`) and matched any fence line without tracking fence length or nesting depth.
   - When encountering an opening fence of a nested code block (such as ```typescript inside a ```markdown block), the parser mistakenly treated it as the closing delimiter of the parent block, dumping subsequent lines as plain text and later opening a reversed code block.
   - **Fix**: The parser now tracks `codeFenceLength` and `nestedCodeDepth`. In accordance with CommonMark standards, a block opened with $N$ backticks cannot be closed by a delimiter with fewer backticks or one bearing a language identifier. Nested blocks inside Markdown/MD fences are cleanly tracked without premature termination.

2. **Curly Braces Preservation**:
   - `cleanLatexMath` previously included a global replacement that stripped braces indiscriminately from text outside code blocks.
   - This corrupted TypeScript object types and signatures (e.g., `{ signal?: AbortSignal }` becoming `signal?: AbortSignal`) and JSON structures whenever lines were rendered inline.
   - **Fix**: Removed the indiscriminate stripping of curly braces; LaTeX command arguments, fractions, superscripts/subscripts, and escaped braces continue to be properly handled by their dedicated extractors.

3. **Word-Boundary Chunk Splitting**:
   - In `splitMessage`, when no newline (`\n`) existed in the second half of `maxChars`, the algorithm fell back to slicing abruptly at `maxChars`, cutting words and units in half.
   - **Fix**: Added a fallback to the last space character before falling back to a hard slice, ensuring words and units remain intact across message chunks.

### Testing & Validation

- Added 5 comprehensive automated tests in `test/telegram.test.ts` covering all fixed cases.
- Full test suite passing: 157 / 157 tests pass with 100% success (`npm test`).
- Verified interactively in live conditions via test bot instance.