### PR TITLE
chore(release): v0.5.0-alpha.1 — Voice I/O, Workspace Scoping & Expandable Quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0-alpha.1] - 2026-09-06
+
+### Added
+- **Voice I/O Capabilities (Speech-to-Text & Text-to-Speech)**: Complete native voice interaction with pluggable adapters, strictly opt-in by default (`STT_PROVIDER=none`, `TTS_MODE=off`):
+  - **Speech-to-Text (STT)**: Transcribes inbound Telegram voice notes into prompt text using `gemini` (cloud audio buffer), `whisper-local` (offline local whisper CLI), or `agy` (multimodal CLI transcription). Includes interactive `/stt` settings keyboard and language selection.
+  - **Text-to-Speech (TTS)**: Synthesizes responses into native Telegram voice notes using `edge-tts` with natural code indicator replacement. Includes `/tts` configuration and flexible response modes (`auto`, `voice-and-text`, `voice-only`).
+- **Per-Session Workspace Scoping (`/workspace`)**:
+  - Dynamically switch working directories per session with `/workspace <name|path>` or `/workspace clear`.
+  - **Forum Topics Binding**: Dedicated project topics persistently bind to their target repository across `/new` resets.
+  - **1:1 DM Ephemeral Reset (Option A)**: Private chats automatically revert to default `AGY_WORKSPACE` on `/new` to preserve friction-free daily assistant workflows.
+  - **Interactive Project Picker**: Paginated inline keyboard listing available project directories.
+  - **Security Boundary**: Strict `isWithin` path containment against authorized root directories to prevent directory traversal.
+- **Expandable Delegation Blockquotes**:
+  - Automatically isolates intermediate subagent execution turns into native Telegram `<blockquote expandable>` above the final response in `verbose: detailed` mode, while cleanly omitting them in `compact` mode.
+
+### Fixed
+- **Nested Code Fence Rendering**: Correctly parses nested code blocks (e.g. internal code fences within Markdown documentation blocks) using CommonMark fence length and nesting depth tracking.
+- **Brace Stripping in LaTeX Math**: Preserved object and TypeScript type curly braces (`{}`) in regular text by targeting only actual LaTeX command argument blocks.
+- **Word-Boundary Chunk Splitting**: Slices long messages on whitespace boundaries instead of cutting words in half when line breaks are absent.
+
 ## [0.4.0] - 2026-09-03
 
 ### Added
@@ -152,6 +172,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Standalone AGY Telegram gateway
 - TypeScript migration
 
+[0.5.0-alpha.1]: https://github.com/ardiannurcahya/antigravity-cli-telegram-bot/compare/v0.4.0...v0.5.0-alpha.1
 [0.4.0]: https://github.com/ardiannurcahya/antigravity-cli-telegram-bot/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/ardiannurcahya/antigravity-cli-telegram-bot/compare/v0.2.0...v0.3.1
 [0.2.0]: https://github.com/ardiannurcahya/antigravity-cli-telegram-bot/compare/v0.1.8...v0.2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agy-telegram",
-  "version": "0.4.0",
+  "version": "0.5.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agy-telegram",
-      "version": "0.4.0",
+      "version": "0.5.0-alpha.1",
       "license": "MIT",
       "bin": {
         "agy-telegram": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agy-telegram",
-  "version": "0.4.0",
+  "version": "0.5.0-alpha.1",
   "description": "Connect the Antigravity CLI to Telegram through a secure, allowlisted bot gateway.",
   "keywords": [
     "telegram",


### PR DESCRIPTION
## Summary

Prepares release **v0.5.0-alpha.1** bumping version from `0.4.0` to `0.5.0-alpha.1` and updating the changelog with all features, fixes, and ecosystem improvements landed on `main`.

### Key Highlights Included in this Milestone

1. **Voice I/O Capabilities (Speech-to-Text & Text-to-Speech) (#33)**:
   - Inbound voice note transcription via `gemini`, `whisper-local`, or `agy` with `/stt` settings.
   - Outbound voice response synthesis via `edge-tts` with `/tts` settings.
   - Strictly opt-in by default (`STT_PROVIDER=none`, `TTS_MODE=off`).
2. **Per-Session Workspace Scoping & Forum Topic Isolation (#28)**:
   - Dynamic directory switching via `/workspace <name|path>` and interactive picker keyboard.
   - Persistent binding across `/new` in Forum Topics.
   - Ephemeral Option A reset on `/new` in 1:1 DMs.
   - Strict `isWithin` path boundary traversal validation.
3. **Expandable Subagent Delegation Blockquotes (#30)**:
   - Isolates intermediate turn preambles into native Telegram `<blockquote expandable>` above final replies.
   - Omitted cleanly in `compact` verbose mode.
4. **Markdown & Code Fence Fixes (#32)**:
   - Correctly renders nested code fences according to CommonMark standards.
   - Preserves curly braces (`{}`) in TypeScript types and JSON.
   - Word-boundary chunk splitting to avoid cutting words in half.

### Validation
- All **170 automated tests passing** cleanly (`npm test`).
- TypeScript build (`tsc`) passes with 0 errors.
