### PR TITLE
docs: remove residual Option A references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ service under a dedicated Unix user.
 - Clean modular architecture (`domain`, `infra`, `router`, `telegram`, `ui`, `usecases`).
 - Hardened security: Bitwise 128-bit IPv6 SSRF protection, strict path containment (`isWithin`), secret scrubbing, and safe permission defaults.
 - Dangerous plugin, update, install, and permission operations require an explicit second confirmation.
-- Per-session workspace isolation: scope AGY's working directory dynamically with `/workspace <name|path>`, automatically reverting to global root on `/new` in 1:1 DMs (Option A) and preserving topic binding in forum supergroups.
+- Per-session workspace isolation: scope AGY's working directory dynamically with `/workspace <name|path>`, automatically reverting to global root on `/new` in 1:1 DMs and preserving topic binding in forum supergroups.
 - AGY is restricted to the configured workspace by default.
 
 ## Architecture
@@ -298,7 +298,7 @@ For software development workflows, `/workspace` enables scoping the working dir
 /workspace clear           # Revert back to the default AGY_WORKSPACE
 ```
 
-#### Lifecycle and Mental Model (Option A)
+#### Lifecycle and Mental Model
 - **1:1 Direct Messages (Ephemeral)**: Starting a new conversation with `/new` automatically resets the session **and** reverts the workspace back to `AGY_WORKSPACE`. This ensures ad-hoc debugging or coding sessions never accidentally linger or trap subsequent personal assistant tasks in a code repository.
 - **Forum Topics (Persistent Binding)**: In Telegram supergroups with forum topics, running `/new` within a dedicated topic clears the conversation history but **preserves the topic's project workspace binding**. This allows project-specific threads (e.g. `#my-app`) to stay anchored to their repository.
 - **Visual Feedback on Prompt**: When a custom workspace is bound to a session, every prompt immediately displays a clear workspace confirmation banner in the live progress message (`📁 Workspace: /path/to/project`).


### PR DESCRIPTION
### Description

This PR cleans up residual references to "Option A" in `README.md`.

During earlier design trade-offs for per-session workspace scoping (#26 / #28), the session reset behavior (ephemeral reset in 1:1 DMs vs. persistent binding in forum topics) was internally referred to as "Option A". Because this is the standard nominal behavior of the bot, keeping this label in the public documentation causes unnecessary confusion as if alternative modes were available.

Please accept our sincere apologies for introducing these internal design notes into the public documentation in the first place!

### Changes

- `README.md`: Removed `(Option A)` from the feature highlights section.
- `README.md`: Renamed `#### Lifecycle and Mental Model (Option A)` to `#### Lifecycle and Mental Model`.
